### PR TITLE
Remove 4-team limit and switch to hex color palette

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -17,6 +17,7 @@ class DashboardController < AuthenticatedController
         latest_activity: latest_activity || Date.new(1900, 1, 1)
       }
     end.sort_by { |standing| [-standing[:points], -standing[:latest_activity].to_time.to_i] }
+      .take(3)
 
     # Get top mentees for the season
     if @current_season && @season_date_range

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,7 +8,28 @@ class TeamsController < AuthenticatedController
 
   # GET /admin/teams or /admin/teams.json
   def index
-    @teams = Team.all
+    season_date_range = current_season_date_range
+
+    # Build ranked teams with points and mentee counts
+    ranked = Team.left_joins(:mentees)
+                 .select("teams.*, COUNT(mentees.id) AS mentees_count")
+                 .group("teams.id")
+                 .map { |t| { team: t, points: t.total_points(season_date_range) } }
+                 .sort_by { |t| [-t[:points], t[:team].name] }
+
+    @team_ranks = {}
+    current_rank = 1
+    previous_points = nil
+    ranked.each do |t|
+      if previous_points && t[:points] < previous_points
+        current_rank += 1
+      end
+      previous_points = t[:points]
+      @team_ranks[t[:team].id] = current_rank
+    end
+
+    # Paginate the pre-sorted list
+    @teams = Kaminari.paginate_array(ranked.map { |t| t[:team] }).page(params[:page])
   end
 
   # GET /admin/teams/1 or /admin/teams/1.json
@@ -114,14 +135,8 @@ class TeamsController < AuthenticatedController
     end
 
     def authorize_create
-      unless current_user.can?(:create, :teams)
-        redirect_to teams_path, alert: "You don't have permission to create teams"
-        return
-      end
-
-      unless Team.colors_available?
-        redirect_to teams_path, alert: "All team colors are in use. Delete a team to create a new one."
-      end
+      return if current_user.can?(:create, :teams)
+      redirect_to teams_path, alert: "You don't have permission to create teams"
     end
 
     def authorize_edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def team_color_badge(team)
+    content_tag(:span, class: "inline-flex items-center gap-1.5 px-2 text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800") do
+      content_tag(:span, "", class: "h-2 w-2 rounded-full", style: "background-color: #{team.color_hex}") +
+        team.name
+    end
+  end
+
+  def team_color_swatch(team, size: "h-5 w-5")
+    content_tag(:span, "", class: "#{size} inline-block rounded-full", style: "background-color: #{team.color_hex}")
+  end
 end

--- a/app/javascript/controllers/color_picker_controller.js
+++ b/app/javascript/controllers/color_picker_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "trigger", "grid"]
+  static values = { selected: String }
+
+  connect() {
+    if (this.selectedValue) {
+      this.inputTarget.value = this.selectedValue
+    }
+    this.closeHandler = (event) => {
+      if (this.isOpen() && !this.element.contains(event.target)) {
+        this.close()
+      }
+    }
+    document.addEventListener("click", this.closeHandler)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeHandler)
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    if (this.isOpen()) {
+      this.close()
+    } else {
+      this.open()
+    }
+  }
+
+  open() {
+    this.gridTarget.classList.remove("hidden")
+  }
+
+  close() {
+    this.gridTarget.classList.add("hidden")
+  }
+
+  isOpen() {
+    return !this.gridTarget.classList.contains("hidden")
+  }
+
+  select(event) {
+    event.preventDefault()
+    const color = event.params.color
+
+    this.inputTarget.value = color
+    this.triggerTarget.style.backgroundColor = color
+    this.close()
+  }
+}

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,21 +2,19 @@ class Team < ApplicationRecord
   has_many :mentees, dependent: :nullify
   belongs_to :icon, class_name: "Medium", optional: true
 
-  enum :color, { blue: "blue", green: "green", yellow: "yellow", red: "red" }
+  COLORS = %w[
+    #E11D48 #F97316 #F59E0B #84CC16 #22C55E #10B981 #14B8A6 #06B6D4
+    #0EA5E9 #3B82F6 #6366F1 #8B5CF6 #A855F7 #D946EF #EC4899 #F43F5E
+    #F87171 #FB7185 #0F172A #64748B #7C2D12 #166534 #1E3A8A #0F766E #92400E
+  ].freeze
 
   validates :name, presence: true, uniqueness: true
-  validates :color, presence: true
-  validate :color_must_be_available, on: :create
+  validates :color, presence: true, format: { with: /\A#[0-9A-Fa-f]{6}\z/, message: "must be a valid hex color" }
 
   after_destroy :cleanup_icon_medium
 
-  def self.available_colors
-    taken = pluck(:color)
-    colors.keys - taken
-  end
-
-  def self.colors_available?
-    available_colors.any?
+  def color_hex
+    color
   end
 
   # Calculate total points for all mentees on this team for a given date range
@@ -45,15 +43,6 @@ class Team < ApplicationRecord
   end
 
   private
-
-  def color_must_be_available
-    return if color.blank?
-
-    taken_colors = Team.where.not(id: id).pluck(:color)
-    if taken_colors.include?(color)
-      errors.add(:color, "has already been taken")
-    end
-  end
 
   def current_season_date_range
     current_season = OlympicSeason.current_season

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -11,7 +11,10 @@
 
     <% if @current_season %>
       <div class="mt-6">
-        <h2 class="text-xl font-semibold text-gray-900 mb-4">Team Leaderboard</h2>
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-xl font-semibold text-gray-900">Team Leaderboard</h2>
+          <%= link_to "View All", teams_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
+        </div>
         <div class="flex flex-col">
           <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
@@ -66,12 +69,9 @@
                             </div>
                           </td>
                           <td class="px-6 py-4 whitespace-nowrap">
-                            <%= link_to standing[:team].name, team_path(standing[:team]), class: "text-sm font-medium text-gray-900 hover:text-indigo-600" %>
-                            <div class="text-sm text-gray-500">
-                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= standing[:team].color %>-100 text-<%= standing[:team].color %>-800">
-                                <%= standing[:team].color.titleize %>
-                              </span>
-                            </div>
+                            <%= link_to team_path(standing[:team]), class: "hover:opacity-80" do %>
+                              <%= team_color_badge(standing[:team]) %>
+                            <% end %>
                           </td>
                           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                             <%= standing[:member_count] %> <%= "member".pluralize(standing[:member_count]) %>
@@ -127,9 +127,7 @@
                             <% end %>
                             <div class="text-sm text-gray-500">
                               <% if mentee_data[:user].mentee&.team %>
-                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= mentee_data[:user].mentee&.team.color %>-100 text-<%= mentee_data[:user].mentee&.team.color %>-800">
-                                  <%= mentee_data[:user].mentee&.team.name %>
-                                </span>
+                                <%= team_color_badge(mentee_data[:user].mentee.team) %>
                               <% end %>
                             </div>
                           </div>
@@ -175,9 +173,7 @@
                             <% end %>
                             <div class="text-sm text-gray-500">
                               <% if mentee_data[:user].mentee&.team %>
-                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= mentee_data[:user].mentee&.team.color %>-100 text-<%= mentee_data[:user].mentee&.team.color %>-800">
-                                  <%= mentee_data[:user].mentee&.team.name %>
-                                </span>
+                                <%= team_color_badge(mentee_data[:user].mentee.team) %>
                               <% end %>
                             </div>
                           </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -124,9 +124,7 @@
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                           <% if log.user.mentee&.team %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= log.user.mentee.team.color %>-100 text-<%= log.user.mentee.team.color %>-800">
-                              <%= log.user.mentee.team.name %>
-                            </span>
+                            <%= team_color_badge(log.user.mentee.team) %>
                           <% else %>
                             <span class="text-sm text-gray-500">—</span>
                           <% end %>
@@ -196,9 +194,7 @@
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                           <% if log.user.mentee&.team %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= log.user.mentee.team.color %>-100 text-<%= log.user.mentee.team.color %>-800">
-                              <%= log.user.mentee.team.name %>
-                            </span>
+                            <%= team_color_badge(log.user.mentee.team) %>
                           <% else %>
                             <span class="text-sm text-gray-500">—</span>
                           <% end %>

--- a/app/views/mentees/index.html.erb
+++ b/app/views/mentees/index.html.erb
@@ -64,9 +64,7 @@
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap">
                     <% if mentee.team %>
-                      <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= mentee.team.color %>-100 text-<%= mentee.team.color %>-800">
-                        <%= mentee.team.name %>
-                      </span>
+                      <%= team_color_badge(mentee.team) %>
                     <% else %>
                       <span class="text-sm text-gray-500">—</span>
                     <% end %>

--- a/app/views/mentees/show.html.erb
+++ b/app/views/mentees/show.html.erb
@@ -39,9 +39,7 @@
             <dt class="text-sm font-medium text-gray-500">Team</dt>
             <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
               <% if @mentee.team %>
-                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= @mentee.team.color %>-100 text-<%= @mentee.team.color %>-800">
-                  <%= @mentee.team.name %>
-                </span>
+                <%= team_color_badge(@mentee.team) %>
               <% else %>
                 —
               <% end %>

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -26,10 +26,30 @@
             <%= form.text_field :name, class: "mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" %>
           </div>
 
-          <div class="col-span-6 sm:col-span-3">
+          <div class="col-span-6 sm:col-span-3" data-controller="color-picker" data-color-picker-selected-value="<%= team.color %>">
             <%= form.label :color, class: "block text-sm font-medium text-gray-700" %>
-            <% available = team.persisted? ? (Team.available_colors + [team.color]).uniq : Team.available_colors %>
-            <%= form.select :color, available.map { |k| [k.titleize, k] }, {}, { class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" } %>
+            <%= form.hidden_field :color, data: { color_picker_target: "input" } %>
+            <div class="mt-2 relative">
+              <button type="button"
+                data-action="click->color-picker#toggle"
+                data-color-picker-target="trigger"
+                class="h-9 w-9 rounded-full cursor-pointer focus:outline-none ring-2 ring-offset-2 ring-gray-400"
+                style="background-color: <%= team.color.present? ? team.color : '#E11D48' %>">
+              </button>
+              <div data-color-picker-target="grid" class="hidden absolute z-10 mt-2 p-3 bg-white rounded-lg shadow-lg border border-gray-200">
+                <div class="grid grid-cols-5 gap-2">
+                  <% Team::COLORS.each do |hex| %>
+                    <button type="button"
+                      data-action="click->color-picker#select"
+                      data-color-picker-color-param="<%= hex %>"
+                      class="h-9 w-9 rounded-full cursor-pointer focus:outline-none hover:scale-110 transition-transform"
+                      style="background-color: <%= hex %>"
+                      title="<%= hex %>">
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div class="col-span-6 sm:col-span-3">

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -2,7 +2,7 @@
   <div class="px-4 py-6 sm:px-0">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-3xl font-bold text-gray-900">Teams</h1>
-      <% if current_user.can?(:create, :teams) && Team.colors_available? %>
+      <% if current_user.can?(:create, :teams) %>
         <%= link_to "New Team", new_team_path, class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700" %>
       <% end %>
     </div>
@@ -21,6 +21,9 @@
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Name
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -28,6 +31,9 @@
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Icon
+                  </th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    # Mentees
                   </th>
                   <th scope="col" class="relative px-6 py-3">
                     <span class="sr-only">Actions</span>
@@ -37,16 +43,28 @@
               <tbody class="bg-white divide-y divide-gray-200">
                 <% if @teams.any? %>
                   <% @teams.each do |team| %>
+                    <% rank = @team_ranks[team.id] %>
                     <tr>
+                      <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="flex items-center">
+                          <% if rank == 1 %>
+                            <span class="text-2xl">🥇</span>
+                          <% elsif rank == 2 %>
+                            <span class="text-2xl">🥈</span>
+                          <% elsif rank == 3 %>
+                            <span class="text-2xl">🥉</span>
+                          <% else %>
+                            <span class="text-sm font-medium text-gray-900"><%= rank %></span>
+                          <% end %>
+                        </div>
+                      </td>
                       <td class="px-6 py-4 whitespace-nowrap">
                         <div class="text-sm font-medium text-gray-900">
                           <%= link_to team.name, team_path(team), class: "text-indigo-600 hover:text-indigo-900" %>
                         </div>
                       </td>
                       <td class="px-6 py-4 whitespace-nowrap">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                          <%= team.color.titleize %>
-                        </span>
+                        <%= team_color_swatch(team) %>
                       </td>
                       <td class="px-6 py-4 whitespace-nowrap">
                         <% if team.icon.present? %>
@@ -55,20 +73,20 @@
                           <span class="text-sm text-gray-500">—</span>
                         <% end %>
                       </td>
+                      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <%= team.mentees_count %>
+                      </td>
                       <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <%= link_to "View", team_path(team), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                         <% if current_user.can?(:edit, :teams) %>
                           <%= link_to "Edit", edit_team_path(team), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
-                        <% end %>
-                        <% if current_user.can?(:delete, :teams) %>
-                          <%= button_to "Delete", team_path(team), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure?" }, form: { class: "inline" } %>
                         <% end %>
                       </td>
                     </tr>
                   <% end %>
                 <% else %>
                   <tr>
-                    <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">No teams found.</td>
+                    <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">No teams found.</td>
                   </tr>
                 <% end %>
               </tbody>
@@ -76,6 +94,9 @@
           </div>
         </div>
       </div>
+    </div>
+    <div class="mt-4">
+      <%= paginate @teams %>
     </div>
   </div>
 </div>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -36,9 +36,7 @@
           <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
             <dt class="text-sm font-medium text-gray-500">Color</dt>
             <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                <%= @team.color.titleize %>
-              </span>
+              <%= team_color_swatch(@team) %>
             </dd>
           </div>
           <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,9 +63,7 @@
               <dt class="text-sm font-medium text-gray-500">Team</dt>
               <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
                 <% if @user.mentee.team.present? %>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= @user.mentee.team.color %>-100 text-<%= @user.mentee.team.color %>-800">
-                    <%= @user.mentee.team.name %>
-                  </span>
+                  <%= team_color_badge(@user.mentee.team) %>
                 <% else %>
                   <span class="text-gray-500">Unassigned</span>
                 <% end %>
@@ -148,9 +146,7 @@
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
                           <% if mentee.team.present? %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= mentee.team.color %>-100 text-<%= mentee.team.color %>-800">
-                              <%= mentee.team.name %>
-                            </span>
+                            <%= team_color_badge(mentee.team) %>
                           <% else %>
                             <span class="text-sm text-gray-500">Unassigned</span>
                           <% end %>

--- a/db/migrate/20260223052407_convert_team_colors_to_hex.rb
+++ b/db/migrate/20260223052407_convert_team_colors_to_hex.rb
@@ -1,0 +1,27 @@
+class ConvertTeamColorsToHex < ActiveRecord::Migration[8.0]
+  def up
+    color_map = {
+      "blue" => "#3B82F6",
+      "green" => "#22C55E",
+      "yellow" => "#F59E0B",
+      "red" => "#E11D48"
+    }
+
+    color_map.each do |old_color, hex_color|
+      execute "UPDATE teams SET color = '#{hex_color}' WHERE color = '#{old_color}'"
+    end
+  end
+
+  def down
+    color_map = {
+      "#3B82F6" => "blue",
+      "#22C55E" => "green",
+      "#F59E0B" => "yellow",
+      "#E11D48" => "red"
+    }
+
+    color_map.each do |hex_color, old_color|
+      execute "UPDATE teams SET color = '#{old_color}' WHERE color = '#{hex_color}'"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_13_193301) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_23_052407) do
   create_table "community_service_records", force: :cascade do |t|
     t.boolean "approved", default: true, null: false
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,23 +5,42 @@
 puts "Seeding database..."
 
 # Create Teams
-blue_team = Team.find_or_create_by!(name: "Blue Team") do |team|
-  team.color = :blue
+team_definitions = [
+  { name: "Blue Team", color: "#3B82F6" },
+  { name: "Green Team", color: "#22C55E" },
+  { name: "Yellow Team", color: "#F59E0B" },
+  { name: "Red Team", color: "#E11D48" },
+  { name: "Orange Team", color: "#F97316" },
+  { name: "Emerald Team", color: "#10B981" },
+  { name: "Teal Team", color: "#14B8A6" },
+  { name: "Cyan Team", color: "#06B6D4" },
+  { name: "Sky Team", color: "#0EA5E9" },
+  { name: "Indigo Team", color: "#6366F1" },
+  { name: "Violet Team", color: "#8B5CF6" },
+  { name: "Purple Team", color: "#A855F7" },
+  { name: "Fuchsia Team", color: "#D946EF" },
+  { name: "Pink Team", color: "#EC4899" },
+  { name: "Rose Team", color: "#F43F5E" },
+  { name: "Lime Team", color: "#84CC16" },
+  { name: "Slate Team", color: "#64748B" },
+  { name: "Navy Team", color: "#1E3A8A" },
+  { name: "Forest Team", color: "#166534" },
+  { name: "Amber Team", color: "#92400E" }
+]
+
+all_teams = team_definitions.map do |defn|
+  Team.find_or_create_by!(name: defn[:name]) do |team|
+    team.color = defn[:color]
+  end
 end
 
-green_team = Team.find_or_create_by!(name: "Green Team") do |team|
-  team.color = :green
-end
+puts "Created #{all_teams.size} teams"
 
-yellow_team = Team.find_or_create_by!(name: "Yellow Team") do |team|
-  team.color = :yellow
-end
-
-red_team = Team.find_or_create_by!(name: "Red Team") do |team|
-  team.color = :red
-end
-
-puts "Created 4 teams"
+# Named references for backward compatibility
+blue_team = all_teams[0]
+green_team = all_teams[1]
+yellow_team = all_teams[2]
+red_team = all_teams[3]
 
 # Helper method to create user with role profile
 def create_user_with_role(email:, password: "Password1!", first_name:, last_name:, active: true, &block)
@@ -59,12 +78,9 @@ green_guardian = green_guardian_user.guardian
 puts "Created 2 guardians"
 
 # Create mentors and mentees for each team
-teams_data = [
-  { team: blue_team, color: "Blue" },
-  { team: green_team, color: "Green" },
-  { team: yellow_team, color: "Yellow" },
-  { team: red_team, color: "Red" }
-]
+teams_data = all_teams.map do |team|
+  { team: team, label: team.name.sub(" Team", "") }
+end
 
 all_mentors = []
 all_mentees = []
@@ -72,13 +88,14 @@ all_mentee_users = []
 
 teams_data.each do |team_data|
   team = team_data[:team]
-  color = team_data[:color]
+  label = team_data[:label]
+  prefix = label.downcase.gsub(/\s+/, "-")
 
   # Create 2 mentors per team
   2.times do |i|
     mentor_user = create_user_with_role(
-      email: "#{color.downcase}.mentor#{i + 1}@example.com",
-      first_name: color,
+      email: "#{prefix}.mentor#{i + 1}@example.com",
+      first_name: label,
       last_name: "Mentor #{i + 1}"
     ) do |user|
       Mentor.find_or_create_by!(user: user)
@@ -89,8 +106,8 @@ teams_data.each do |team_data|
   # Create 7 mentees per team
   7.times do |i|
     mentee_user = create_user_with_role(
-      email: "#{color.downcase}.mentee#{i + 1}@example.com",
-      first_name: color,
+      email: "#{prefix}.mentee#{i + 1}@example.com",
+      first_name: label,
       last_name: "Mentee #{i + 1}"
     ) do |user|
       mentee = Mentee.find_or_create_by!(user: user)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -235,7 +235,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "should create mentee user with team and mentor" do
     login_as(@user)
-    team = Team.create!(name: "Test Team", color: :blue)
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     mentor = @inactive_user.mentor # Already has mentor from setup
 
     assert_difference ["User.count", "Mentee.count"], 1 do
@@ -546,7 +546,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "should change role to mentee with team and mentor" do
     login_as(@user)
-    team = Team.create!(name: "New Team", color: :green)
+    team = Team.create!(name: "New Team", color: "#22C55E")
     mentor = @inactive_user.mentor
 
     patch user_path(@volunteer_user), params: {

--- a/test/graphql/mutations/family_members_test.rb
+++ b/test/graphql/mutations/family_members_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class FamilyMembersMutationsTest < ActiveSupport::TestCase
   def setup
-    @team = Team.create!(name: "Test Team", color: :blue)
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
 
     @admin = create_user(email: "admin@example.com")
     @staff = create_staff_user(email: "staff@example.com")

--- a/test/graphql/mutations/teams_test.rb
+++ b/test/graphql/mutations/teams_test.rb
@@ -8,7 +8,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     @staff = create_staff_user(email: "staff@example.com")
     @mentor = create_mentor_user(email: "mentor@example.com")
 
-    @team = Team.create!(name: "Existing Team", color: :blue)
+    @team = Team.create!(name: "Existing Team", color: "#3B82F6")
   end
 
   # CreateTeam tests
@@ -30,7 +30,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "New Team",
-        color: "red"
+        color: "#E11D48"
       }
     }, context: { current_user: @admin })
 
@@ -39,7 +39,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
 
     assert_not_nil team
     assert_equal "New Team", team["name"]
-    assert_equal "red", team["color"]
+    assert_equal "#E11D48", team["color"]
     assert_empty errors
   end
 
@@ -59,7 +59,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "Staff Team",
-        color: "green"
+        color: "#22C55E"
       }
     }, context: { current_user: @staff })
 
@@ -87,7 +87,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "Mentor Team",
-        color: "yellow"
+        color: "#F59E0B"
       }
     }, context: { current_user: @mentor })
 
@@ -123,7 +123,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "Icon Team",
-        color: "yellow",
+        color: "#F59E0B",
         iconId: medium.id.to_s
       }
     }, context: { current_user: @admin })
@@ -151,7 +151,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "Existing Team",
-        color: "red"
+        color: "#E11D48"
       }
     }, context: { current_user: @admin })
 
@@ -177,7 +177,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
     result = execute_graphql(mutation, variables: {
       input: {
         name: "New Team",
-        color: "red"
+        color: "#E11D48"
       }
     }, context: {})
 
@@ -205,7 +205,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
       input: {
         id: @team.id.to_s,
         name: "Updated Team Name",
-        color: "green"
+        color: "#22C55E"
       }
     }, context: { current_user: @admin })
 
@@ -214,7 +214,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
 
     assert_not_nil team
     assert_equal "Updated Team Name", team["name"]
-    assert_equal "green", team["color"]
+    assert_equal "#22C55E", team["color"]
     assert_empty errors
   end
 
@@ -247,7 +247,7 @@ class TeamsMutationsTest < ActiveSupport::TestCase
   # DeleteTeam tests
 
   test "admin can delete team" do
-    team_to_delete = Team.create!(name: "Delete Me", color: :red)
+    team_to_delete = Team.create!(name: "Delete Me", color: "#E11D48")
 
     mutation = <<~GQL
       mutation($id: ID!) {

--- a/test/graphql/mutations/users_test.rb
+++ b/test/graphql/mutations/users_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class UsersMutationsTest < ActiveSupport::TestCase
   def setup
-    @team = Team.create!(name: "Test Team", color: :blue)
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
 
     @admin = create_user(email: "admin@example.com")
     @staff = create_staff_user(email: "staff@example.com")

--- a/test/graphql/mutations_test.rb
+++ b/test/graphql/mutations_test.rb
@@ -9,7 +9,7 @@ class GraphQL::MutationsTest < ActiveSupport::TestCase
     @token = AuthService.generate_token(@user)
 
     # Create test data
-    @team = Team.create!(name: "Test Team", color: :blue)
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
     @event_type = EventType.create!(name: "Test Event Type", point_value: 10, category: :org)
   end
 
@@ -29,7 +29,7 @@ class GraphQL::MutationsTest < ActiveSupport::TestCase
     GQL
 
     result = execute_graphql(mutation, variables: {
-      input: { name: "New Team", color: "red" }
+      input: { name: "New Team", color: "#E11D48" }
     }, context: { current_user: @user })
 
     team_data = result.dig("data", "createTeam", "team")
@@ -37,7 +37,7 @@ class GraphQL::MutationsTest < ActiveSupport::TestCase
 
     assert_not_nil team_data
     assert_equal "New Team", team_data["name"]
-    assert_equal "red", team_data["color"]
+    assert_equal "#E11D48", team_data["color"]
     assert_empty errors
   end
 
@@ -179,7 +179,7 @@ class GraphQL::MutationsTest < ActiveSupport::TestCase
     GQL
 
     result = execute_graphql(mutation, variables: {
-      input: { name: "New Team", color: "red" }
+      input: { name: "New Team", color: "#E11D48" }
     }, context: {})
 
     assert_nil result.dig("data", "createTeam")

--- a/test/graphql/queries_test.rb
+++ b/test/graphql/queries_test.rb
@@ -44,7 +44,7 @@ class GraphQL::QueriesTest < ActiveSupport::TestCase
     teams = result.dig("data", "teams")
 
     assert_not_nil teams
-    assert_equal 4, teams.length
+    assert_equal 20, teams.length
     assert_includes teams.map { |t| t["name"] }, "Blue Team"
   end
 

--- a/test/models/community_service_record_test.rb
+++ b/test/models/community_service_record_test.rb
@@ -6,7 +6,7 @@ class CommunityServiceRecordTest < ActiveSupport::TestCase
       email: "mentee@example.com",
       password: "Password123!"
     )
-    @team = Team.create!(name: "Test Team", color: "blue")
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
     @mentee = Mentee.create!(user: @user, team: @team)
 
     @record = CommunityServiceRecord.new(

--- a/test/models/family_member_test.rb
+++ b/test/models/family_member_test.rb
@@ -6,7 +6,7 @@ class FamilyMemberTest < ActiveSupport::TestCase
     @mentee_user = User.create!(email: "mentee@example.com", password: "Password123!")
 
     @guardian = Guardian.create!(user: @guardian_user)
-    @team = Team.create!(name: "Test Team", color: "blue")
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
     @mentee = Mentee.create!(user: @mentee_user, team: @team)
 
     @family_member = FamilyMember.new(

--- a/test/models/guardian_test.rb
+++ b/test/models/guardian_test.rb
@@ -38,7 +38,7 @@ class GuardianTest < ActiveSupport::TestCase
   test "can have multiple children" do
     @guardian.save!
 
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
 
     mentee_user1 = User.create!(email: "mentee1@example.com", password: "Password123!")
     mentee_user2 = User.create!(email: "mentee2@example.com", password: "Password123!")
@@ -57,7 +57,7 @@ class GuardianTest < ActiveSupport::TestCase
   test "children with different relationship types" do
     @guardian.save!
 
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
 
     child_user = User.create!(email: "child@example.com", password: "Password123!")
     grandchild_user = User.create!(email: "grandchild@example.com", password: "Password123!")
@@ -74,7 +74,7 @@ class GuardianTest < ActiveSupport::TestCase
 
   test "destroying guardian destroys family_member associations" do
     @guardian.save!
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     mentee_user = User.create!(email: "mentee@example.com", password: "Password123!")
     mentee = Mentee.create!(user: mentee_user, team: team)
 

--- a/test/models/mentee_test.rb
+++ b/test/models/mentee_test.rb
@@ -6,7 +6,7 @@ class MenteeTest < ActiveSupport::TestCase
       email: "mentee@example.com",
       password: "Password123!"
     )
-    @team = Team.create!(name: "Test Team", color: "blue")
+    @team = Team.create!(name: "Test Team", color: "#3B82F6")
     @mentee = Mentee.new(user: @user, team: @team)
   end
 
@@ -85,7 +85,7 @@ class MenteeTest < ActiveSupport::TestCase
 
   # Team relationship
   test "can be assigned to a team" do
-    new_team = Team.create!(name: "New Team", color: "red")
+    new_team = Team.create!(name: "New Team", color: "#E11D48")
     @mentee.team = new_team
     @mentee.save!
 

--- a/test/models/mentor_test.rb
+++ b/test/models/mentor_test.rb
@@ -34,7 +34,7 @@ class MentorTest < ActiveSupport::TestCase
   test "can have multiple mentees" do
     @mentor.save!
 
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
 
     mentee_user1 = User.create!(email: "mentee1@example.com", password: "Password123!")
     mentee_user2 = User.create!(email: "mentee2@example.com", password: "Password123!")
@@ -49,7 +49,7 @@ class MentorTest < ActiveSupport::TestCase
 
   test "destroying mentor nullifies mentee associations" do
     @mentor.save!
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     mentee_user = User.create!(email: "mentee@example.com", password: "Password123!")
     mentee = Mentee.create!(user: mentee_user, mentor: @mentor, team: team)
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class TeamTest < ActiveSupport::TestCase
   def setup
-    @team = Team.new(name: "Test Team", color: "blue")
+    @team = Team.new(name: "Test Team", color: "#3B82F6")
   end
 
   # Validations
@@ -24,42 +24,62 @@ class TeamTest < ActiveSupport::TestCase
 
   test "name must be unique" do
     @team.save!
-    duplicate = Team.new(name: "Test Team", color: "red")
+    duplicate = Team.new(name: "Test Team", color: "#E11D48")
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:name], "has already been taken"
   end
 
-  # Color enum with string values
-  test "has color enum" do
-    assert_respond_to @team, :color
-    assert_respond_to @team, :blue?
-    assert_respond_to @team, :green?
-    assert_respond_to @team, :yellow?
-    assert_respond_to @team, :red?
+  # Hex color validation
+  test "accepts valid hex color" do
+    @team.color = "#FF5733"
+    assert @team.valid?
   end
 
-  test "can set color to blue" do
+  test "accepts lowercase hex color" do
+    @team.color = "#ff5733"
+    assert @team.valid?
+  end
+
+  test "rejects color without hash" do
+    @team.color = "3B82F6"
+    assert_not @team.valid?
+    assert_includes @team.errors[:color], "must be a valid hex color"
+  end
+
+  test "rejects color with wrong length" do
+    @team.color = "#FFF"
+    assert_not @team.valid?
+    assert_includes @team.errors[:color], "must be a valid hex color"
+  end
+
+  test "rejects non-hex characters" do
+    @team.color = "#ZZZZZZ"
+    assert_not @team.valid?
+    assert_includes @team.errors[:color], "must be a valid hex color"
+  end
+
+  test "rejects plain color names" do
     @team.color = "blue"
-    @team.save!
-    assert @team.blue?
+    assert_not @team.valid?
+    assert_includes @team.errors[:color], "must be a valid hex color"
   end
 
-  test "can set color to green" do
-    @team.color = "green"
-    @team.save!
-    assert @team.green?
+  # COLORS constant
+  test "has COLORS constant with 25 colors" do
+    assert_equal 25, Team::COLORS.length
+    assert Team::COLORS.all? { |c| c.match?(/\A#[0-9A-Fa-f]{6}\z/) }
   end
 
-  test "can set color to yellow" do
-    @team.color = "yellow"
-    @team.save!
-    assert @team.yellow?
+  # color_hex helper
+  test "color_hex returns the color value" do
+    assert_equal "#3B82F6", @team.color_hex
   end
 
-  test "can set color to red" do
-    @team.color = "red"
+  # Multiple teams can share the same color
+  test "allows duplicate colors" do
     @team.save!
-    assert @team.red?
+    second_team = Team.new(name: "Second Team", color: "#3B82F6")
+    assert second_team.valid?
   end
 
   # Associations - now with Mentee instead of User
@@ -194,7 +214,7 @@ class TeamTest < ActiveSupport::TestCase
 
   test "total_community_service_hours excludes records from other teams" do
     @team.save!
-    other_team = Team.create!(name: "Other Team", color: "red")
+    other_team = Team.create!(name: "Other Team", color: "#E11D48")
 
     today = Date.current
     OlympicSeason.create!(

--- a/test/models/user_role_associations_test.rb
+++ b/test/models/user_role_associations_test.rb
@@ -36,7 +36,7 @@ class UserRoleAssociationsTest < ActiveSupport::TestCase
   end
 
   test "can create mentee profile for user" do
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     mentee = Mentee.create!(user: @user, team: team)
     assert_equal mentee, @user.mentee
   end
@@ -100,7 +100,7 @@ class UserRoleAssociationsTest < ActiveSupport::TestCase
   end
 
   test "destroying user destroys associated mentee profile" do
-    team = Team.create!(name: "Test Team", color: "blue")
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     Mentee.create!(user: @user, team: team)
 
     assert_difference "Mentee.count", -1 do

--- a/test/services/messages_service_test.rb
+++ b/test/services/messages_service_test.rb
@@ -197,7 +197,7 @@ class MessagesServiceTest < ActiveSupport::TestCase
   end
 
   test "compose expands group:team:id for staff" do
-    team = Team.create!(name: "Test Team", color: :blue)
+    team = Team.create!(name: "Test Team", color: "#3B82F6")
     @mentee_user.mentee.update!(team: team)
     service = MessagesService.new(@admin)
 
@@ -848,7 +848,7 @@ class MessagesServiceTest < ActiveSupport::TestCase
   end
 
   test "compose_recipients includes team groups for staff" do
-    team = Team.create!(name: "Alpha Team", color: :green)
+    team = Team.create!(name: "Alpha Team", color: "#22C55E")
     service = MessagesService.new(@admin)
 
     result = service.compose_recipients


### PR DESCRIPTION
## Summary
- Replace team color enum (blue/green/yellow/red) with a 25-color hex palette, removing the 4-team limit
- Add color picker swatch grid with Stimulus controller for team create/edit forms
- Add team ranking (dense ranking with medal icons for top 3) to dashboard and teams index
- Limit dashboard leaderboard to top 3 teams with "View All" link to teams page
- Add pagination to teams index
- Seed 20 teams with unique names and colors
- Update all views to use hex color swatches/badges via helpers

## Test plan
- [ ] Verify existing teams display correctly with hex colors
- [ ] Create new teams using the color picker swatch grid
- [ ] Confirm dashboard shows top 3 teams with correct ranking
- [ ] Confirm "View All" link navigates to /teams
- [ ] Verify teams index shows rank, name, color swatch, icon, mentee count
- [ ] Confirm pagination works on teams index
- [ ] Verify color badges display correctly across dashboard, mentees, users, and events views
- [ ] Run full test suite (`bin/rails test`)