### PR TITLE
feat: Add points history and management system

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < AuthenticatedController
   before_action :require_users_navigation_or_related_access
-  before_action :set_user, only: [:show, :edit, :update, :destroy, :activate, :deactivate, :add_family_member, :remove_family_member, :create_guardian, :add_mentee, :remove_mentee, :reset_password, :add_event_log, :remove_event_log, :add_grade_card, :remove_grade_card, :send_seas_evaluation, :redeem_incentive, :deny_redemption, :delete_redemption]
+  before_action :set_user, only: [:show, :edit, :update, :destroy, :activate, :deactivate, :add_family_member, :remove_family_member, :create_guardian, :add_mentee, :remove_mentee, :reset_password, :add_event_log, :remove_event_log, :add_grade_card, :remove_grade_card, :send_seas_evaluation, :redeem_incentive, :deny_redemption, :delete_redemption, :point_history, :adjust_points]
   before_action :authorize_index, only: [:index]
   before_action :authorize_show, only: [:show, :reset_password]
   before_action :authorize_edit, only: [:edit, :update]
@@ -412,6 +412,54 @@ class UsersController < AuthenticatedController
     end
 
     redirect_to user_path(@user), notice: "Incentive redemption deleted#{" and points refunded" if params[:refund_points] == "1"}"
+  end
+
+  def point_history
+    return redirect_to user_path(@user), alert: "User is not a mentee" unless @user.mentee.present?
+    return redirect_to user_path(@user), alert: "You don't have permission to manage points" unless current_user.can?(:manage_points, :users)
+
+    @point_logs = @user.mentee.point_logs.page(params[:page])
+  end
+
+  def adjust_points
+    return redirect_to user_path(@user), alert: "User is not a mentee" unless @user.mentee.present?
+    return redirect_to user_path(@user), alert: "You don't have permission to manage points" unless current_user.can?(:manage_points, :users)
+
+    points = params[:points].to_i
+    reason = params[:reason].to_s.strip
+
+    # Validation
+    if points == 0
+      return redirect_to user_path(@user), alert: "Points adjustment must not be zero"
+    end
+
+    if reason.blank?
+      return redirect_to user_path(@user), alert: "Reason is required"
+    end
+
+    # Calculate what the new total would be
+    new_total = @user.mentee.total_points + points
+
+    # Check that points won't go below 0
+    if new_total < 0
+      return redirect_to user_path(@user), alert: "Cannot reduce points below zero. Current: #{@user.mentee.total_points}, Adjustment: #{points}"
+    end
+
+    # Create the point log
+    point_log = PointLog.create!(
+      mentee: @user.mentee,
+      points: points,
+      reason: reason,
+      awarded_by: current_user,
+      log_type: "adjustment"
+    )
+
+    # Send message if requested
+    if params[:send_message] == "1" && params[:message_text].present?
+      PointAdjustmentMessage.new(point_log, author: current_user, message_text: params[:message_text]).deliver
+    end
+
+    redirect_to user_path(@user), notice: "Points adjusted successfully. #{"+" if points > 0}#{points} points (#{new_total} total)"
   end
 
   private

--- a/app/javascript/controllers/points_manager_controller.js
+++ b/app/javascript/controllers/points_manager_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["pointsDisplay", "pointsInput", "resultDisplay", "messageArea"]
+  static values = {
+    currentPoints: Number,
+    adjustment: { type: Number, default: 0 }
+  }
+
+  connect() {
+    // Get current points from the display element
+    const resultElement = this.resultDisplayTarget
+    const currentPointsText = resultElement.textContent
+    this.currentPointsValue = parseInt(currentPointsText.replace(/[^0-9-]/g, '')) || 0
+    this.updateDisplay()
+  }
+
+  increment() {
+    this.adjustmentValue += 1
+    this.updateDisplay()
+  }
+
+  decrement() {
+    // Prevent going below 0 total points
+    const newTotal = this.currentPointsValue + this.adjustmentValue - 1
+    if (newTotal < 0) {
+      // Flash a warning or prevent
+      return
+    }
+    this.adjustmentValue -= 1
+    this.updateDisplay()
+  }
+
+  updateDisplay() {
+    // Update the points display
+    this.pointsDisplayTarget.textContent = this.adjustmentValue >= 0 ? `+${this.adjustmentValue}` : this.adjustmentValue
+    
+    // Update the hidden input
+    this.pointsInputTarget.value = this.adjustmentValue
+    
+    // Update the result display
+    const newTotal = this.currentPointsValue + this.adjustmentValue
+    this.resultDisplayTarget.textContent = `${newTotal}pts`
+    
+    // Color code the result
+    if (newTotal < 0) {
+      this.resultDisplayTarget.classList.remove('text-indigo-600')
+      this.resultDisplayTarget.classList.add('text-red-600')
+    } else {
+      this.resultDisplayTarget.classList.remove('text-red-600')
+      this.resultDisplayTarget.classList.add('text-indigo-600')
+    }
+  }
+
+  toggleMessage(event) {
+    if (event.target.checked) {
+      this.messageAreaTarget.classList.remove('hidden')
+    } else {
+      this.messageAreaTarget.classList.add('hidden')
+    }
+  }
+}

--- a/app/messages/point_adjustment_message.rb
+++ b/app/messages/point_adjustment_message.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class PointAdjustmentMessage < ApplicationMessage
+  def initialize(point_log, author:, message_text:)
+    @point_log = point_log
+    @author_user = author
+    @message_text = message_text
+  end
+
+  def author
+    @author_user
+  end
+
+  def reply_mode
+    :reply_to_sender
+  end
+
+  def subject
+    points_word = (@point_log.points >= 0) ? "Awarded" : "Deducted"
+    "Points #{points_word}: #{@point_log.points.abs} points"
+  end
+
+  def body
+    points_word = (@point_log.points >= 0) ? "awarded" : "deducted"
+    new_total = @point_log.mentee.total_points
+
+    <<~BODY
+      Your points have been adjusted.
+
+      **Points #{points_word}:** #{@point_log.points.abs}
+      **New Total:** #{new_total} points
+      **Reason:** #{@point_log.reason}
+
+      #{@message_text}
+
+      If you have questions, please reply to this message.
+    BODY
+  end
+
+  def recipients
+    [@point_log.mentee.user]
+  end
+end

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,10 +1,12 @@
 class EventLog < ApplicationRecord
   belongs_to :event
   belongs_to :user
+  has_one :point_log, as: :source, dependent: :destroy
 
   enum :log_type, { registered: "registered", arrived: "arrived" }
 
   before_validation :stamp_event_data, on: :create
+  after_create :create_point_log_entry, if: :should_create_point_log?
 
   validates :event_id, presence: true
   validates :user_id, presence: true
@@ -26,5 +28,22 @@ class EventLog < ApplicationRecord
 
     # Auto-set timestamp if not provided
     self.logged_at ||= Time.current
+  end
+
+  def should_create_point_log?
+    log_type == "arrived" && user&.mentee? && points_awarded > 0
+  end
+
+  def create_point_log_entry
+    return unless user&.mentee?
+
+    PointLog.create!(
+      mentee: user.mentee,
+      points: points_awarded,
+      reason: "Attended #{event.name} on #{event.event_date.strftime("%B %d, %Y")}",
+      awarded_by: nil, # Automated attendance - no specific user
+      log_type: "attendance",
+      source: self
+    )
   end
 end

--- a/app/models/mentee.rb
+++ b/app/models/mentee.rb
@@ -9,6 +9,7 @@ class Mentee < ApplicationRecord
   has_many :grade_cards, dependent: :destroy
   has_many :seas_evaluations, dependent: :destroy
   has_many :redemptions, dependent: :destroy
+  has_many :point_logs, dependent: :destroy
 
   # Check if mentee can afford a redemption of specified points
   # Uses row-level locking to prevent race conditions
@@ -24,15 +25,7 @@ class Mentee < ApplicationRecord
     date_range ||= current_season_date_range
     return 0 unless date_range
 
-    earned = user.event_logs.joins(:event)
-      .where(events: { event_date: date_range })
-      .sum(:points_awarded)
-
-    spent = redemptions.active
-      .where(created_at: date_range)
-      .sum(:points_spent)
-
-    earned - spent
+    point_logs.where(created_at: date_range).sum(:points)
   end
 
   # Calculate total approved community service hours for a given date range

--- a/app/models/point_log.rb
+++ b/app/models/point_log.rb
@@ -1,0 +1,51 @@
+class PointLog < ApplicationRecord
+  belongs_to :mentee
+  belongs_to :awarded_by, class_name: "User", optional: true
+  belongs_to :source, polymorphic: true, optional: true
+
+  LOG_TYPES = %w[attendance redemption adjustment].freeze
+
+  validates :points, presence: true, numericality: { only_integer: true }
+  validates :reason, presence: true
+  validates :log_type, presence: true, inclusion: { in: LOG_TYPES }
+  validates :mentee, presence: true
+
+  default_scope { order(created_at: :desc) }
+
+  # Badge color for UI based on log type
+  def badge_color
+    case log_type
+    when "attendance"
+      "green"
+    when "redemption"
+      "red"
+    when "adjustment"
+      "indigo"
+    else
+      "gray"
+    end
+  end
+
+  # Display name for log type
+  def log_type_display
+    case log_type
+    when "attendance"
+      "Attendance"
+    when "redemption"
+      "Redemption"
+    when "adjustment"
+      "Adjustment"
+    else
+      log_type.titleize
+    end
+  end
+
+  # Awarded by display name
+  def awarded_by_display
+    if log_type == "attendance" && source.is_a?(EventLog)
+      "Attending"
+    else
+      awarded_by&.email || "System"
+    end
+  end
+end

--- a/app/models/redemption.rb
+++ b/app/models/redemption.rb
@@ -4,6 +4,7 @@ class Redemption < ApplicationRecord
   belongs_to :mentee
   belongs_to :incentive
   belongs_to :approved_by, class_name: "User", optional: true
+  has_many :point_logs, as: :source, dependent: :destroy
 
   validates :points_spent, presence: true, numericality: { greater_than: 0 }
   validates :status, presence: true, inclusion: { in: STATUSES }
@@ -16,8 +17,46 @@ class Redemption < ApplicationRecord
   scope :active, -> { where(status: %w[pending approved deleted_no_refund]) }
   scope :visible, -> { where(status: %w[pending approved]) }
 
+  # Create point log when redemption is created (pending or approved)
+  after_create :create_deduction_point_log, if: :should_deduct_points?
+
+  # Create refund point log when redemption is deleted
+  after_update :create_refund_point_log, if: :saved_change_to_deleted?
+
   def pending? = status == "pending"
   def approved? = status == "approved"
   def denied? = status == "denied"
   def deleted? = status == "deleted"
+
+  private
+
+  def should_deduct_points?
+    pending? || approved? || status == "deleted_no_refund"
+  end
+
+  def create_deduction_point_log
+    PointLog.create!(
+      mentee: mentee,
+      points: -points_spent,
+      reason: "Redeemed: #{incentive.name}",
+      awarded_by: approved_by, # May be nil for pending redemptions
+      log_type: "redemption",
+      source: self
+    )
+  end
+
+  def saved_change_to_deleted?
+    saved_change_to_status? && status == "deleted"
+  end
+
+  def create_refund_point_log
+    PointLog.create!(
+      mentee: mentee,
+      points: points_spent,
+      reason: "Refund for deleted redemption: #{incentive.name}",
+      awarded_by: approved_by, # May be nil
+      log_type: "adjustment",
+      source: self
+    )
+  end
 end

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -1,7 +1,7 @@
 class Authorization
   PERMISSIONS = {
     admin: {
-      users: [:index, :show, :create, :edit, :delete, :change_status, :manage_family_members, :manage_mentees, :manage_event_logs],
+      users: [:index, :show, :create, :edit, :delete, :change_status, :manage_family_members, :manage_mentees, :manage_event_logs, :manage_points],
       events: [:index, :show, :create, :edit, :delete],
       teams: [:index, :show, :create, :edit, :delete, :manage_members],
       incentives: [:index, :show, :create, :edit, :delete, :manage_redemptions],
@@ -14,7 +14,7 @@ class Authorization
       navigation: [:dashboard, :users, :teams, :incentives, :events, :inbox, :community_service, :settings, :saturday_scoops]
     },
     staff: {
-      users: [:index, :show, :create, :edit, :manage_family_members, :manage_mentees, :manage_event_logs],
+      users: [:index, :show, :create, :edit, :manage_family_members, :manage_mentees, :manage_event_logs, :manage_points],
       events: [:index, :show, :create, :edit, :delete],
       teams: [:index, :show, :create, :edit, :delete, :manage_members],
       incentives: [:index, :show, :create, :edit, :delete, :manage_redemptions],

--- a/app/views/users/point_history.html.erb
+++ b/app/views/users/point_history.html.erb
@@ -1,0 +1,76 @@
+<div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+  <div class="px-4 py-6 sm:px-0">
+    <%= render "shared/breadcrumbs", items: [
+      { label: "Users", path: users_path },
+      { label: @user.email, path: user_path(@user) },
+      { label: "Point History" }
+    ] %>
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <div class="px-4 py-5 sm:px-6">
+        <h3 class="text-lg leading-6 font-medium text-gray-900">Points History</h3>
+        <p class="mt-1 text-sm text-gray-500">View history of mentees' points</p>
+      </div>
+      <div class="border-t border-gray-200">
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Type
+                </th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Awarded On
+                </th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Awarded By
+                </th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  # of Points
+                </th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Reason
+                </th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <% if @point_logs.any? %>
+                <% @point_logs.each do |log| %>
+                  <tr>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                      <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-<%= log.badge_color %>-100 text-<%= log.badge_color %>-800">
+                        <%= log.log_type_display %>
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <%= log.created_at.strftime("%B %d, %Y") %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <%= log.awarded_by_display %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium <%= log.points >= 0 ? 'text-green-600' : 'text-red-600' %>">
+                      <%= log.points >= 0 ? "+" : "" %><%= log.points %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <%= log.reason %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% else %>
+                <tr>
+                  <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+                    No point history found
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+        <% if @point_logs.total_pages > 1 %>
+          <div class="px-4 py-3 border-t border-gray-200 sm:px-6">
+            <%= paginate @point_logs %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,6 @@
         <% end %>
       </div>
     </div>
-
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h3 class="text-lg leading-6 font-medium text-gray-900">User Information</h3>
@@ -82,556 +81,865 @@
                 <% end %>
               </dd>
             </div>
+            <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt class="text-sm font-medium text-gray-500">Points</dt>
+              <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center space-x-4">
+                    <span class="text-lg font-bold text-gray-900"><%= @user.mentee.total_points %></span>
+                    <%= link_to point_history_user_path(@user), class: "text-sm text-indigo-600 hover:text-indigo-900" do %>
+                      <svg class="inline-block h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      </svg>
+                      History
+                    <% end %>
+                  </div>
+                  <% if current_user.can?(:manage_points, :users) %>
+                    <button type="button"
+                            data-controller="modal"
+                            data-action="click->modal#open"
+                      data-modal-target="manage-points-modal"
+                      class="inline-flex items-center px-3 py-1.5 border border-indigo-600 text-xs font-medium rounded-md text-indigo-600 bg-white hover:bg-indigo-50">
+                      Manage Points
+                    </button>
+                  <% end %>
+                </div>
+              </dd>
+            </div>
           <% end %>
         </dl>
       </div>
     </div>
-
+    <% if @user.mentee.present? && current_user.can?(:manage_points, :users) %>
+      <!-- Manage Points Modal -->
+      <div id="manage-points-modal" data-controller="modal points-manager" class="hidden fixed inset-0 z-50" data-modal-target="dialog">
+        <div data-modal-target="backdrop" data-action="click->modal#closeOnBackdrop" class="fixed inset-0 bg-black/50 transition-opacity"></div>
+        <div class="fixed inset-0 z-10 overflow-y-auto">
+          <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Manage Points</h3>
+                <p class="mt-1 text-sm text-gray-500">Add, or subtract points</p>
+                <%= form_with url: adjust_points_user_path(@user), method: :post, class: "mt-4 space-y-4", data: { controller: "points-manager" } do |f| %>
+                  <div class="flex items-center justify-center space-x-4">
+                    <button type="button" data-action="click->points-manager#decrement" class="p-2 rounded-full bg-gray-100 hover:bg-gray-200">
+                      <svg class="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14" />
+                      </svg>
+                    </button>
+                    <span data-points-manager-target="pointsDisplay" class="text-4xl font-bold text-gray-900">0</span>
+                    <button type="button" data-action="click->points-manager#increment" class="p-2 rounded-full bg-indigo-100 hover:bg-indigo-200">
+                      <svg class="h-5 w-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                      </svg>
+                    </button>
+                  </div>
+                  <%= f.hidden_field :points, value: 0, data: { "points-manager-target": "pointsInput" } %>
+                  <div class="flex items-center justify-between border-t border-gray-200 pt-4">
+                    <div class="text-center">
+                      <span class="text-2xl font-bold text-gray-900"><%= @user.mentee.total_points %>pts</span>
+                      <p class="text-xs text-gray-500">Current points</p>
+                    </div>
+                    <div class="flex items-center text-gray-400">
+                      <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+                      </svg>
+                    </div>
+                    <div class="text-center">
+                      <span data-points-manager-target="resultDisplay" class="text-2xl font-bold text-indigo-600"><%= @user.mentee.total_points %>pts</span>
+                      <p class="text-xs text-gray-500">Points after adjustment</p>
+                    </div>
+                  </div>
+                  <div>
+                    <%= f.label :reason, "Reason", class: "block text-sm font-medium text-gray-700" %>
+                    <%= f.text_field :reason, required: true, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm", placeholder: "Enter reason for point adjustment..." %>
+                  </div>
+                  <div>
+                    <label class="flex items-center">
+                      <%= f.check_box :send_message, { class: "h-4 w-4 text-indigo-600 border-gray-300 rounded", data: { action: "change->points-manager#toggleMessage" } }, "1", nil %>
+                      <span class="ml-2 text-sm text-gray-700">Send message with points modification</span>
+                    </label>
+                  </div>
+                  <div data-points-manager-target="messageArea" class="hidden">
+                    <%= f.label :message_text, "Message", class: "block text-sm font-medium text-gray-700" %>
+                    <%= f.text_area :message_text, rows: 3, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm", placeholder: "Enter optional message..." %>
+                  </div>
+                  <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+                    <%= f.submit "Save", class: "inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:col-start-2 cursor-pointer" %>
+                    <button type="button" data-action="click->modal#close" class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">Cancel</button>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <!-- Redemptions (only for mentees) -->
     <% if @user.mentee.present? %>
-    <div class="mt-6">
-      <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">
-          Redemptions
-          <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @redemptions&.count || 0 %></span>
-        </h3>
-      </div>
-
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Incentive
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Redeemed on
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Approved by
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    </th>
-                  </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                  <% if @redemptions&.any? %>
-                    <% @redemptions.each do |redemption| %>
-                      <tr data-controller="modal redemption-form">
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <div class="flex items-center">
-                            <% if redemption.incentive.image.present? %>
-                              <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="<%= redemption.incentive.name %>" class="h-10 w-10 object-cover rounded">
-                            <% else %>
-                              <div class="h-10 w-10 rounded bg-gray-100 flex items-center justify-center">
-                                <svg class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
-                              </div>
-                            <% end %>
-                            <div class="ml-4">
-                              <div class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></div>
-                              <div class="text-sm text-gray-500"><%= redemption.incentive.description %></div>
-                            </div>
-                          </div>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          <%= redemption.created_at.strftime("%B %d, %Y") %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <% if redemption.pending? %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                              Awaiting Approval
-                            </span>
-                          <% elsif redemption.approved? %>
-                            <span class="text-sm text-gray-900"><%= redemption.approved_by&.email %></span>
-                          <% end %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <% if @can_manage_redemptions %>
-                            <% if redemption.pending? %>
-                              <button type="button"
-                                      data-action="click->modal#open"
-                                      class="inline-flex items-center px-3 py-1.5 border border-indigo-600 text-sm font-medium rounded-md text-indigo-600 bg-white hover:bg-indigo-50">
-                                Redeem Incentive
-                              </button>
-
-                              <!-- Redeem/Deny Modal -->
-                              <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
-                                <div data-modal-target="backdrop"
-                                     data-action="click->modal#closeOnBackdrop"
-                                     class="fixed inset-0 bg-black/50 transition-opacity"></div>
-
-                                <div class="fixed inset-0 z-10 overflow-y-auto">
-                                  <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-                                    <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                        <!-- Redeem View -->
-                                        <div data-redemption-form-target="redeemView">
-                                          <h3 class="text-lg font-medium leading-6 text-gray-900">Redeem Incentive</h3>
-                                          <p class="mt-1 text-sm text-gray-500">Redeem an incentive for a mentee</p>
-
-                                          <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
-                                            <% if redemption.incentive.image.present? %>
-                                              <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
-                                            <% else %>
-                                              <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
-                                                <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
-                                              </div>
-                                            <% end %>
-                                            <div class="ml-4">
-                                              <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
-                                              <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
-                                            </div>
-                                          </div>
-
-                                          <%= form_with url: redeem_incentive_user_path(@user), method: :post, class: "mt-4" do %>
-                                            <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
-
-                                            <div class="flex items-center">
-                                              <input type="checkbox" name="send_message" value="1" id="send_message_redeem_<%= redemption.id %>"
-                                                     data-action="change->redemption-form#toggleMessage"
-                                                     class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                                              <label for="send_message_redeem_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Send message with redemption</label>
-                                            </div>
-
-                                            <div data-redemption-form-target="messageArea" class="hidden mt-3">
-                                              <textarea name="message_text" rows="3"
-                                                        class="block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                                                        placeholder="Message"></textarea>
-                                            </div>
-
-                                            <div class="mt-5 flex items-center justify-between">
-                                              <button type="button"
-                                                      data-action="click->redemption-form#showDeny"
-                                                      class="text-sm font-medium text-red-600 hover:text-red-500">
-                                                Deny Redemption
-                                              </button>
-                                              <div class="flex space-x-3">
-                                                <button type="button"
-                                                        data-action="click->modal#close"
-                                                        class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                                                  Cancel
-                                                </button>
-                                                <button type="submit"
-                                                        class="inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
-                                                  Redeem
-                                                </button>
-                                              </div>
-                                            </div>
-                                          <% end %>
-                                        </div>
-
-                                        <!-- Deny View -->
-                                        <div data-redemption-form-target="denyView" class="hidden">
-                                          <h3 class="text-lg font-medium leading-6 text-gray-900">Deny Redemption</h3>
-                                          <p class="mt-1 text-sm text-gray-500">Deny this incentive redemption request</p>
-
-                                          <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
-                                            <% if redemption.incentive.image.present? %>
-                                              <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
-                                            <% else %>
-                                              <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
-                                                <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
-                                              </div>
-                                            <% end %>
-                                            <div class="ml-4">
-                                              <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
-                                              <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
-                                            </div>
-                                          </div>
-
-                                          <%= form_with url: deny_redemption_user_path(@user), method: :post, class: "mt-4" do %>
-                                            <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
-
-                                            <div>
-                                              <label class="block text-sm font-medium text-gray-700">Reason for denial</label>
-                                              <textarea name="notes" rows="3" required
-                                                        class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm"
-                                                        placeholder="Please explain why this redemption is being denied..."></textarea>
-                                            </div>
-
-                                            <div class="mt-5 flex items-center justify-between">
-                                              <button type="button"
-                                                      data-action="click->redemption-form#showRedeem"
-                                                      class="text-sm font-medium text-gray-600 hover:text-gray-500">
-                                                Back
-                                              </button>
-                                              <div class="flex space-x-3">
-                                                <button type="button"
-                                                        data-action="click->modal#close"
-                                                        class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                                                  Cancel
-                                                </button>
-                                                <button type="submit"
-                                                        class="inline-flex justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 cursor-pointer">
-                                                  Deny
-                                                </button>
-                                              </div>
-                                            </div>
-                                          <% end %>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-
-                            <% elsif redemption.approved? %>
-                              <button type="button"
-                                      data-action="click->modal#open"
-                                      class="text-gray-400 hover:text-red-600">
-                                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
-                              </button>
-
-                              <!-- Delete Modal -->
-                              <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
-                                <div data-modal-target="backdrop"
-                                     data-action="click->modal#closeOnBackdrop"
-                                     class="fixed inset-0 bg-black/50 transition-opacity"></div>
-
-                                <div class="fixed inset-0 z-10 overflow-y-auto">
-                                  <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-                                    <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                        <h3 class="text-lg font-medium leading-6 text-gray-900">Delete Redemption</h3>
-                                        <p class="mt-1 text-sm text-gray-500">Delete and refund redeemed incentive</p>
-
-                                        <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
-                                          <% if redemption.incentive.image.present? %>
-                                            <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
-                                          <% else %>
-                                            <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
-                                              <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
-                                            </div>
-                                          <% end %>
-                                          <div class="ml-4">
-                                            <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
-                                            <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
-                                          </div>
-                                        </div>
-
-                                        <%= form_with url: delete_redemption_user_path(@user), method: :delete, data: { controller: "redemption-form" }, class: "mt-4 space-y-4" do %>
-                                          <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
-
-                                          <div>
-                                            <label class="block text-sm font-medium text-gray-700">Reason</label>
-                                            <textarea name="reason" rows="2" required
-                                                      class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm"
-                                                      placeholder="Reason for deletion..."></textarea>
-                                          </div>
-
-                                          <div class="flex items-center">
-                                            <input type="checkbox" name="refund_points" value="1" id="refund_points_<%= redemption.id %>"
-                                                   class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                                            <label for="refund_points_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Refund Points</label>
-                                          </div>
-
-                                          <div class="flex items-center">
-                                            <input type="checkbox" name="send_message" value="1" id="send_message_delete_<%= redemption.id %>"
-                                                   data-action="change->redemption-form#toggleMessage"
-                                                   class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
-                                            <label for="send_message_delete_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Send message with deletion</label>
-                                          </div>
-
-                                          <div data-redemption-form-target="messageArea" class="hidden">
-                                            <textarea name="message_text" rows="3"
-                                                      class="block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                                                      placeholder="Message"></textarea>
-                                          </div>
-
-                                          <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                                            <button type="submit"
-                                                    class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:col-start-2 cursor-pointer">
-                                              Delete
-                                            </button>
-                                            <button type="button"
-                                                    data-action="click->modal#close"
-                                                    class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
-                                              Cancel
-                                            </button>
-                                          </div>
-                                        <% end %>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            <% end %>
-                          <% end %>
-                        </td>
-                      </tr>
-                    <% end %>
-                  <% else %>
-                    <tr>
-                      <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">
-                        No redemptions
-                      </td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-          </div>
+      <div class="mt-6">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg leading-6 font-medium text-gray-900">
+            Redemptions
+            <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @redemptions&.count || 0 %></span>
+          </h3>
         </div>
-      </div>
-    </div>
-    <% end %>
-
-    <!-- SEAS Self Evaluations (only for mentees) -->
-    <% if @user.mentee.present? %>
-    <div class="mt-6">
-      <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">
-          SEAS Self Evaluations
-          <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @seas_evaluations&.count || 0 %></span>
-        </h3>
-        <% if current_user.can?(:send, :seas_evaluations) %>
-          <%= button_to "Send SEAS Evaluation", send_seas_evaluation_user_path(@user), method: :post, class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700", data: { turbo_confirm: "Send a SEAS evaluation email to #{@user.email}?" } %>
-        <% end %>
-      </div>
-
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Evaluation Date</th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Score</th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    <% if current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations) %>
-                      <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
-                    <% end %>
-                  </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                  <% if @seas_evaluations&.any? %>
-                    <% @seas_evaluations.each do |evaluation| %>
-                      <tr>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          <%= (evaluation.completed_at || evaluation.created_at).strftime("%B %d, %Y") %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                          <% if evaluation.status == "reviewed" %>
-                            <%= evaluation.final_total_score %>
-                          <% end %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <% case evaluation.status %>
-                          <% when "pending" %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Pending</span>
-                          <% when "in_progress" %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">In Progress</span>
-                          <% when "submitted" %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-amber-100 text-amber-800">Awaiting Review</span>
-                          <% when "in_review" %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">In Review</span>
-                          <% when "reviewed" %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Reviewed</span>
-                          <% end %>
-                        </td>
-                        <% if current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations) %>
-                          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                            <% if current_user.can?(:review, :seas_evaluations) %>
-                              <% case evaluation.status %>
-                              <% when "submitted" %>
-                                <%= link_to "Review", review_seas_evaluation_path(evaluation), class: "text-indigo-600 hover:text-indigo-900" %>
-                              <% when "in_review" %>
-                                <% if evaluation.reviewer == current_user %>
-                                  <%= link_to "Continue Review", review_seas_evaluation_path(evaluation), class: "text-indigo-600 hover:text-indigo-900" %>
-                                <% else %>
-                                  <%= link_to "View", review_seas_evaluation_path(evaluation), class: "text-gray-600 hover:text-gray-900" %>
-                                <% end %>
-                              <% when "reviewed" %>
-                                <%= link_to "View", review_seas_evaluation_path(evaluation), class: "text-gray-600 hover:text-gray-900" %>
+        <div class="flex flex-col">
+          <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Incentive
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Redeemed on
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Approved by
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <% if @redemptions&.any? %>
+                      <% @redemptions.each do |redemption| %>
+                        <tr data-controller="modal redemption-form">
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="flex items-center">
+                              <% if redemption.incentive.image.present? %>
+                                <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="<%= redemption.incentive.name %>" class="h-10 w-10 object-cover rounded">
+                              <% else %>
+                                <div class="h-10 w-10 rounded bg-gray-100 flex items-center justify-center">
+                                  <svg class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
+                                </div>
                               <% end %>
-                            <% end %>
-                            <% if current_user.can?(:delete, :seas_evaluations) %>
-                              <%= button_to "Delete", delete_seas_evaluation_path(evaluation), method: :delete, class: "text-red-600 hover:text-red-900 ml-3", data: { turbo_confirm: "Are you sure you want to delete this SEAS evaluation? This cannot be undone." }, form: { class: "inline" } %>
+                              <div class="ml-4">
+                                <div class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></div>
+                                <div class="text-sm text-gray-500"><%= redemption.incentive.description %></div>
+                              </div>
+                            </div>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <%= redemption.created_at.strftime("%B %d, %Y") %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <% if redemption.pending? %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                                Awaiting Approval
+                              </span>
+                            <% elsif redemption.approved? %>
+                              <span class="text-sm text-gray-900"><%= redemption.approved_by&.email %></span>
                             <% end %>
                           </td>
-                        <% end %>
+                          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                            <% if @can_manage_redemptions %>
+                              <% if redemption.pending? %>
+                                <button type="button"
+                                      data-action="click->modal#open"
+                                  class="inline-flex items-center px-3 py-1.5 border border-indigo-600 text-sm font-medium rounded-md text-indigo-600 bg-white hover:bg-indigo-50">
+                                  Redeem Incentive
+                                </button>
+                                <!-- Redeem/Deny Modal -->
+                                <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
+                                  <div data-modal-target="backdrop"
+                                     data-action="click->modal#closeOnBackdrop"
+                                    class="fixed inset-0 bg-black/50 transition-opacity"></div>
+                                  <div class="fixed inset-0 z-10 overflow-y-auto">
+                                    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                                      <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                                        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                                          <!-- Redeem View -->
+                                          <div data-redemption-form-target="redeemView">
+                                            <h3 class="text-lg font-medium leading-6 text-gray-900">Redeem Incentive</h3>
+                                            <p class="mt-1 text-sm text-gray-500">Redeem an incentive for a mentee</p>
+                                            <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
+                                              <% if redemption.incentive.image.present? %>
+                                                <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
+                                              <% else %>
+                                                <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
+                                                  <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
+                                                </div>
+                                              <% end %>
+                                              <div class="ml-4">
+                                                <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
+                                                <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
+                                              </div>
+                                            </div>
+                                            <%= form_with url: redeem_incentive_user_path(@user), method: :post, class: "mt-4" do %>
+                                              <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
+                                              <div class="flex items-center">
+                                                <input type="checkbox" name="send_message" value="1" id="send_message_redeem_<%= redemption.id %>"
+                                                     data-action="change->redemption-form#toggleMessage"
+                                                class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
+                                                <label for="send_message_redeem_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Send message with redemption</label>
+                                              </div>
+                                              <div data-redemption-form-target="messageArea" class="hidden mt-3">
+                                                <textarea name="message_text" rows="3"
+                                                        class="block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                                                        placeholder="Message"></textarea>
+                                              </div>
+                                              <div class="mt-5 flex items-center justify-between">
+                                                <button type="button"
+                                                      data-action="click->redemption-form#showDeny"
+                                                  class="text-sm font-medium text-red-600 hover:text-red-500">
+                                                  Deny Redemption
+                                                </button>
+                                                <div class="flex space-x-3">
+                                                  <button type="button"
+                                                        data-action="click->modal#close"
+                                                    class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+                                                    Cancel
+                                                  </button>
+                                                  <button type="submit"
+                                                        class="inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
+                                                    Redeem
+                                                  </button>
+                                                </div>
+                                              </div>
+                                            <% end %>
+                                          </div>
+                                          <!-- Deny View -->
+                                          <div data-redemption-form-target="denyView" class="hidden">
+                                            <h3 class="text-lg font-medium leading-6 text-gray-900">Deny Redemption</h3>
+                                            <p class="mt-1 text-sm text-gray-500">Deny this incentive redemption request</p>
+                                            <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
+                                              <% if redemption.incentive.image.present? %>
+                                                <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
+                                              <% else %>
+                                                <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
+                                                  <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
+                                                </div>
+                                              <% end %>
+                                              <div class="ml-4">
+                                                <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
+                                                <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
+                                              </div>
+                                            </div>
+                                            <%= form_with url: deny_redemption_user_path(@user), method: :post, class: "mt-4" do %>
+                                              <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
+                                              <div>
+                                                <label class="block text-sm font-medium text-gray-700">Reason for denial</label>
+                                                <textarea name="notes" rows="3" required
+                                                        class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm"
+                                                        placeholder="Please explain why this redemption is being denied..."></textarea>
+                                              </div>
+                                              <div class="mt-5 flex items-center justify-between">
+                                                <button type="button"
+                                                      data-action="click->redemption-form#showRedeem"
+                                                  class="text-sm font-medium text-gray-600 hover:text-gray-500">
+                                                  Back
+                                                </button>
+                                                <div class="flex space-x-3">
+                                                  <button type="button"
+                                                        data-action="click->modal#close"
+                                                    class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+                                                    Cancel
+                                                  </button>
+                                                  <button type="submit"
+                                                        class="inline-flex justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 cursor-pointer">
+                                                    Deny
+                                                  </button>
+                                                </div>
+                                              </div>
+                                            <% end %>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              <% elsif redemption.approved? %>
+                                <button type="button"
+                                      data-action="click->modal#open"
+                                  class="text-gray-400 hover:text-red-600">
+                                  <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
+                                </button>
+                                <!-- Delete Modal -->
+                                <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
+                                  <div data-modal-target="backdrop"
+                                     data-action="click->modal#closeOnBackdrop"
+                                    class="fixed inset-0 bg-black/50 transition-opacity"></div>
+                                  <div class="fixed inset-0 z-10 overflow-y-auto">
+                                    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                                      <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                                        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                                          <h3 class="text-lg font-medium leading-6 text-gray-900">Delete Redemption</h3>
+                                          <p class="mt-1 text-sm text-gray-500">Delete and refund redeemed incentive</p>
+                                          <div class="mt-4 flex items-center border-b border-gray-200 pb-4">
+                                            <% if redemption.incentive.image.present? %>
+                                              <img src="<%= redemption.incentive.image.thumbnail_url %>" alt="" class="h-14 w-14 object-cover rounded border border-gray-200">
+                                            <% else %>
+                                              <div class="h-14 w-14 rounded border border-gray-200 bg-gray-50 flex items-center justify-center">
+                                                <svg class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
+                                              </div>
+                                            <% end %>
+                                            <div class="ml-4">
+                                              <p class="text-sm font-medium text-gray-900"><%= redemption.incentive.name %></p>
+                                              <p class="text-lg font-bold text-indigo-600"><%= redemption.points_spent %>pts</p>
+                                            </div>
+                                          </div>
+                                          <%= form_with url: delete_redemption_user_path(@user), method: :delete, data: { controller: "redemption-form" }, class: "mt-4 space-y-4" do %>
+                                            <input type="hidden" name="redemption_id" value="<%= redemption.id %>">
+                                            <div>
+                                              <label class="block text-sm font-medium text-gray-700">Reason</label>
+                                              <textarea name="reason" rows="2" required
+                                                      class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm"
+                                                      placeholder="Reason for deletion..."></textarea>
+                                            </div>
+                                            <div class="flex items-center">
+                                              <input type="checkbox" name="refund_points" value="1" id="refund_points_<%= redemption.id %>"
+                                                   class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
+                                              <label for="refund_points_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Refund Points</label>
+                                            </div>
+                                            <div class="flex items-center">
+                                              <input type="checkbox" name="send_message" value="1" id="send_message_delete_<%= redemption.id %>"
+                                                   data-action="change->redemption-form#toggleMessage"
+                                              class="h-4 w-4 text-indigo-600 border-gray-300 rounded">
+                                              <label for="send_message_delete_<%= redemption.id %>" class="ml-2 text-sm text-gray-700">Send message with deletion</label>
+                                            </div>
+                                            <div data-redemption-form-target="messageArea" class="hidden">
+                                              <textarea name="message_text" rows="3"
+                                                      class="block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                                                      placeholder="Message"></textarea>
+                                            </div>
+                                            <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+                                              <button type="submit"
+                                                    class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:col-start-2 cursor-pointer">
+                                                Delete
+                                              </button>
+                                              <button type="button"
+                                                    data-action="click->modal#close"
+                                                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
+                                                Cancel
+                                              </button>
+                                            </div>
+                                          <% end %>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              <% end %>
+                            <% end %>
+                          </td>
+                        </tr>
+                      <% end %>
+                    <% else %>
+                      <tr>
+                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">
+                          No redemptions
+                        </td>
                       </tr>
                     <% end %>
-                  <% else %>
-                    <tr>
-                      <td colspan="<%= (current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations)) ? 4 : 3 %>" class="px-6 py-4 text-center text-sm text-gray-500">No SEAS evaluations</td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
     <% end %>
-
+    <!-- SEAS Self Evaluations (only for mentees) -->
+    <% if @user.mentee.present? %>
+      <div class="mt-6">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg leading-6 font-medium text-gray-900">
+            SEAS Self Evaluations
+            <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @seas_evaluations&.count || 0 %></span>
+          </h3>
+          <% if current_user.can?(:send, :seas_evaluations) %>
+            <%= button_to "Send SEAS Evaluation", send_seas_evaluation_user_path(@user), method: :post, class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700", data: { turbo_confirm: "Send a SEAS evaluation email to #{@user.email}?" } %>
+          <% end %>
+        </div>
+        <div class="flex flex-col">
+          <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Evaluation Date</th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Score</th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                      <% if current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations) %>
+                        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+                      <% end %>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <% if @seas_evaluations&.any? %>
+                      <% @seas_evaluations.each do |evaluation| %>
+                        <tr>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                            <%= (evaluation.completed_at || evaluation.created_at).strftime("%B %d, %Y") %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                            <% if evaluation.status == "reviewed" %>
+                              <%= evaluation.final_total_score %>
+                            <% end %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <% case evaluation.status %>
+                            <% when "pending" %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Pending</span>
+                            <% when "in_progress" %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">In Progress</span>
+                            <% when "submitted" %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-amber-100 text-amber-800">Awaiting Review</span>
+                            <% when "in_review" %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">In Review</span>
+                            <% when "reviewed" %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Reviewed</span>
+                            <% end %>
+                          </td>
+                          <% if current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations) %>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                              <% if current_user.can?(:review, :seas_evaluations) %>
+                                <% case evaluation.status %>
+                                <% when "submitted" %>
+                                  <%= link_to "Review", review_seas_evaluation_path(evaluation), class: "text-indigo-600 hover:text-indigo-900" %>
+                                <% when "in_review" %>
+                                  <% if evaluation.reviewer == current_user %>
+                                    <%= link_to "Continue Review", review_seas_evaluation_path(evaluation), class: "text-indigo-600 hover:text-indigo-900" %>
+                                  <% else %>
+                                    <%= link_to "View", review_seas_evaluation_path(evaluation), class: "text-gray-600 hover:text-gray-900" %>
+                                  <% end %>
+                                <% when "reviewed" %>
+                                  <%= link_to "View", review_seas_evaluation_path(evaluation), class: "text-gray-600 hover:text-gray-900" %>
+                                <% end %>
+                              <% end %>
+                              <% if current_user.can?(:delete, :seas_evaluations) %>
+                                <%= button_to "Delete", delete_seas_evaluation_path(evaluation), method: :delete, class: "text-red-600 hover:text-red-900 ml-3", data: { turbo_confirm: "Are you sure you want to delete this SEAS evaluation? This cannot be undone." }, form: { class: "inline" } %>
+                              <% end %>
+                            </td>
+                          <% end %>
+                        </tr>
+                      <% end %>
+                    <% else %>
+                      <tr>
+                        <td colspan="<%= (current_user.can?(:review, :seas_evaluations) || current_user.can?(:delete, :seas_evaluations)) ? 4 : 3 %>" class="px-6 py-4 text-center text-sm text-gray-500">No SEAS evaluations</td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <!-- Mentees (only for mentors) -->
     <% if @user.mentor.present? %>
-    <div class="mt-6">
-      <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">
-        Mentees (<%= @user.mentor.mentees.count %>)
-      </h3>
-
-      <!-- Add Mentee Form -->
-      <% if @can_manage_mentees %>
-        <div class="mb-4 bg-white shadow sm:rounded-lg p-4">
-          <h4 class="text-sm font-medium text-gray-700 mb-3">Add Mentee</h4>
-          <% if @available_mentees_for_mentor.any? %>
-            <%= form_with url: add_mentee_user_path(@user), method: :post, class: "flex items-end space-x-4" do |f| %>
-              <div class="flex-grow">
-                <%= render "shared/combobox",
+      <div class="mt-6">
+        <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">
+          Mentees (<%= @user.mentor.mentees.count %>)
+        </h3>
+        <!-- Add Mentee Form -->
+        <% if @can_manage_mentees %>
+          <div class="mb-4 bg-white shadow sm:rounded-lg p-4">
+            <h4 class="text-sm font-medium text-gray-700 mb-3">Add Mentee</h4>
+            <% if @available_mentees_for_mentor.any? %>
+              <%= form_with url: add_mentee_user_path(@user), method: :post, class: "flex items-end space-x-4" do |f| %>
+                <div class="flex-grow">
+                  <%= render "shared/combobox",
                     name: "mentee_id",
                     options: @available_mentees_for_mentor.map { |m| ["#{m.user.first_name} #{m.user.last_name} (#{m.user.email})", m.id] },
                     placeholder: "Search mentees..." %>
-              </div>
-              <%= f.submit "Add", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer" %>
+                </div>
+                <%= f.submit "Add", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer" %>
+              <% end %>
+            <% else %>
+              <p class="text-sm text-gray-500">No unassigned mentees available.</p>
             <% end %>
-          <% else %>
-            <p class="text-sm text-gray-500">No unassigned mentees available.</p>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Mentee
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Team
-                    </th>
-                    <% if @can_manage_mentees %>
-                      <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Actions
+          </div>
+        <% end %>
+        <div class="flex flex-col">
+          <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Mentee
                       </th>
-                    <% end %>
-                  </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                  <% if @user.mentor.mentees.any? %>
-                    <% @user.mentor.mentees.includes(:user, :team).each do |mentee| %>
-                      <tr>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <%= link_to user_path(mentee.user), class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" do %>
-                            <%= mentee.user.first_name %> <%= mentee.user.last_name %>
-                          <% end %>
-                          <div class="text-sm text-gray-500"><%= mentee.user.email %></div>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <% if mentee.team.present? %>
-                            <%= team_color_badge(mentee.team) %>
-                          <% else %>
-                            <span class="text-sm text-gray-500">Unassigned</span>
-                          <% end %>
-                        </td>
-                        <% if @can_manage_mentees %>
-                          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                            <%= button_to "Remove", remove_mentee_user_path(@user, mentee_id: mentee.id), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove this mentee from this mentor?" } %>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Team
+                      </th>
+                      <% if @can_manage_mentees %>
+                        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Actions
+                        </th>
+                      <% end %>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <% if @user.mentor.mentees.any? %>
+                      <% @user.mentor.mentees.includes(:user, :team).each do |mentee| %>
+                        <tr>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <%= link_to user_path(mentee.user), class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" do %>
+                              <%= mentee.user.first_name %> <%= mentee.user.last_name %>
+                            <% end %>
+                            <div class="text-sm text-gray-500"><%= mentee.user.email %></div>
                           </td>
-                        <% end %>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <% if mentee.team.present? %>
+                              <%= team_color_badge(mentee.team) %>
+                            <% else %>
+                              <span class="text-sm text-gray-500">Unassigned</span>
+                            <% end %>
+                          </td>
+                          <% if @can_manage_mentees %>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                              <%= button_to "Remove", remove_mentee_user_path(@user, mentee_id: mentee.id), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove this mentee from this mentor?" } %>
+                            </td>
+                          <% end %>
+                        </tr>
+                      <% end %>
+                    <% else %>
+                      <tr>
+                        <td colspan="<%= @can_manage_mentees ? 3 : 2 %>" class="px-6 py-4 text-center text-sm text-gray-500">No mentees assigned</td>
                       </tr>
                     <% end %>
-                  <% else %>
-                    <tr>
-                      <td colspan="<%= @can_manage_mentees ? 3 : 2 %>" class="px-6 py-4 text-center text-sm text-gray-500">No mentees assigned</td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
     <% end %>
-
     <!-- Family Members (only for mentees) -->
     <% if @user.mentee.present? %>
-    <div class="mt-6">
-      <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">
-        Guardians (<%= @user.mentee.guardians.count %>)
-      </h3>
-
-      <!-- Add Guardian Form -->
-      <% if @can_manage_family_members %>
-        <div class="mb-4 bg-white shadow sm:rounded-lg p-4" data-controller="modal">
-          <div class="flex justify-between items-center mb-3">
-            <h4 class="text-sm font-medium text-gray-700">Add Guardian</h4>
-            <button type="button"
+      <div class="mt-6">
+        <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">
+          Guardians (<%= @user.mentee.guardians.count %>)
+        </h3>
+        <!-- Add Guardian Form -->
+        <% if @can_manage_family_members %>
+          <div class="mb-4 bg-white shadow sm:rounded-lg p-4" data-controller="modal">
+            <div class="flex justify-between items-center mb-3">
+              <h4 class="text-sm font-medium text-gray-700">Add Guardian</h4>
+              <button type="button"
                     data-action="click->modal#open"
-                    class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200">
-              + Create New Guardian
-            </button>
-          </div>
-          <% if @available_guardians_for_family.any? %>
-            <%= form_with url: add_family_member_user_path(@user), method: :post, class: "flex items-end space-x-4" do |f| %>
-              <div class="flex-grow">
-                <%= render "shared/combobox",
+                class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200">
+                + Create New Guardian
+              </button>
+            </div>
+            <% if @available_guardians_for_family.any? %>
+              <%= form_with url: add_family_member_user_path(@user), method: :post, class: "flex items-end space-x-4" do |f| %>
+                <div class="flex-grow">
+                  <%= render "shared/combobox",
                     name: "guardian_user_id",
                     label: "Select Guardian",
                     options: @available_guardians_for_family.map { |g| ["#{g.user.first_name} #{g.user.last_name} (#{g.user.email})", g.user.id] },
                     placeholder: "Search guardians..." %>
-              </div>
-              <div class="w-48">
-                <%= label_tag :relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
-                <%= select_tag :relationship_type, options_for_select(@allowed_relationship_types), class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-              </div>
-              <%= f.submit "Add", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer" %>
+                </div>
+                <div class="w-48">
+                  <%= label_tag :relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
+                  <%= select_tag :relationship_type, options_for_select(@allowed_relationship_types), class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                </div>
+                <%= f.submit "Add", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer" %>
+              <% end %>
+            <% else %>
+              <p class="text-sm text-gray-500">No existing guardians available. Create a new guardian using the button above.</p>
             <% end %>
-          <% else %>
-            <p class="text-sm text-gray-500">No existing guardians available. Create a new guardian using the button above.</p>
+            <!-- New Guardian Modal -->
+            <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
+              <div data-modal-target="backdrop"
+                 data-action="click->modal#closeOnBackdrop"
+                class="fixed inset-0 bg-black/50 transition-opacity"></div>
+              <div class="fixed inset-0 z-10 overflow-y-auto">
+                <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                  <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                    <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                      <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Create New Guardian</h3>
+                      <p class="text-sm text-gray-500 mb-4">The guardian will receive an email to confirm their account and set a password.</p>
+                      <%= form_with url: create_guardian_user_path(@user), method: :post, class: "space-y-4", data: { turbo: false } do |f| %>
+                        <div>
+                          <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+                          <%= f.email_field :email, required: true, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm", placeholder: "guardian@example.com" %>
+                        </div>
+                        <div class="grid grid-cols-2 gap-4">
+                          <div>
+                            <%= f.label :first_name, "First Name", class: "block text-sm font-medium text-gray-700" %>
+                            <%= f.text_field :first_name, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                          </div>
+                          <div>
+                            <%= f.label :last_name, "Last Name", class: "block text-sm font-medium text-gray-700" %>
+                            <%= f.text_field :last_name, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                          </div>
+                        </div>
+                        <div>
+                          <%= f.label :relationship_type, "Relationship to Child", class: "block text-sm font-medium text-gray-700" %>
+                          <%= f.select :relationship_type, @allowed_relationship_types, {}, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                        </div>
+                        <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+                          <%= f.submit "Create Guardian", class: "inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:col-start-2 cursor-pointer" %>
+                          <button type="button"
+                                data-action="click->modal#close"
+                            class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
+                            Cancel
+                          </button>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <div class="flex flex-col">
+          <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Guardian
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Relationship
+                      </th>
+                      <% if @can_manage_family_members %>
+                        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Actions
+                        </th>
+                      <% end %>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <% if @user.mentee.family_members.any? %>
+                      <% @user.mentee.family_members.includes(guardian: :user).each do |family_member| %>
+                        <tr>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <%= link_to family_member.guardian.user.email, user_path(family_member.guardian.user), class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
+                            <div class="text-sm text-gray-500">
+                              <%= family_member.guardian.user.first_name %> <%= family_member.guardian.user.last_name %>
+                            </div>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                              <%= family_member.relationship_type.titleize %>
+                            </span>
+                          </td>
+                          <% if @can_manage_family_members %>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                              <%= button_to "Remove", remove_family_member_user_path(@user, family_member_id: family_member.id), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove this guardian?" } %>
+                            </td>
+                          <% end %>
+                        </tr>
+                      <% end %>
+                    <% else %>
+                      <tr>
+                        <td colspan="<%= @can_manage_family_members ? 3 : 2 %>" class="px-6 py-4 text-center text-sm text-gray-500">No guardians</td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <!-- Community Service (only for mentees) -->
+    <% if @user.mentee.present? %>
+      <div class="mt-6">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg leading-6 font-medium text-gray-900">
+            Community Service
+            <% if @current_season %>
+              <span class="ml-2 text-sm font-normal text-gray-500">(<%= @current_season.name %> Season)</span>
+            <% end %>
+          </h3>
+          <div class="text-right">
+            <div class="text-2xl font-bold text-pink-600"><%= @total_community_service_hours || 0 %></div>
+            <div class="text-xs text-gray-500">Total Hours</div>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                  <thead class="bg-gray-50">
+                    <tr>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Activity
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Date
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Hours
+                      </th>
+                      <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Status
+                      </th>
+                      <% if @can_manage_community_service %>
+                        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Actions
+                        </th>
+                      <% end %>
+                    </tr>
+                  </thead>
+                  <tbody class="bg-white divide-y divide-gray-200">
+                    <% if @community_service_records&.any? %>
+                      <% @community_service_records.each do |record| %>
+                        <tr data-controller="modal">
+                          <td class="px-6 py-4">
+                            <div class="text-sm font-medium text-gray-900"><%= record.event %></div>
+                            <% if record.description.present? %>
+                              <div class="text-sm text-gray-500 truncate max-w-xs"><%= record.description %></div>
+                            <% end %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <%= record.event_date.strftime("%b %d, %Y") %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                            <%= record.hours %>
+                          </td>
+                          <td class="px-6 py-4 whitespace-nowrap">
+                            <% if record.approved? %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                Approved
+                              </span>
+                            <% else %>
+                              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                                Denied
+                              </span>
+                            <% end %>
+                          </td>
+                          <% if @can_manage_community_service %>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                              <% if record.approved? %>
+                                <button type="button"
+                                      data-action="click->modal#open"
+                                  class="text-red-600 hover:text-red-900">
+                                  Deny
+                                </button>
+                                <!-- Deny Modal -->
+                                <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
+                                  <div data-modal-target="backdrop"
+                                     data-action="click->modal#closeOnBackdrop"
+                                    class="fixed inset-0 bg-black/50 transition-opacity"></div>
+                                  <div class="fixed inset-0 z-10 overflow-y-auto">
+                                    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+                                      <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                                        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                                          <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Deny Community Service Record</h3>
+                                          <p class="text-sm text-gray-500 mb-4">
+                                            You are denying <strong><%= record.event %></strong> (<%= number_with_precision(record.hours, precision: 1) %> hours) for <%= @user.first_name %> <%= @user.last_name %>.
+                                          </p>
+                                          <%= form_with url: community_service_record_path(record), method: :patch, class: "space-y-4" do |f| %>
+                                            <%= hidden_field_tag :redirect_to, user_path(@user) %>
+                                            <input type="hidden" name="community_service_record[approved]" value="false">
+                                            <div>
+                                              <%= label_tag :denial_reason, "Reason for denial", class: "block text-sm font-medium text-gray-700" %>
+                                              <%= text_area_tag :denial_reason, nil, rows: 3, required: true, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm", placeholder: "Please explain why this record is being denied..." %>
+                                              <p class="mt-1 text-xs text-gray-500">This message will be sent to <%= @user.first_name %>.</p>
+                                            </div>
+                                            <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+                                              <%= f.submit "Deny Record", class: "inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:col-start-2 cursor-pointer" %>
+                                              <button type="button"
+                                                    data-action="click->modal#close"
+                                                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
+                                                Cancel
+                                              </button>
+                                            </div>
+                                          <% end %>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              <% else %>
+                                <%= button_to "Approve", community_service_record_path(record), method: :patch, params: { community_service_record: { approved: true }, redirect_to: user_path(@user) }, class: "text-green-600 hover:text-green-900" %>
+                              <% end %>
+                            </td>
+                          <% end %>
+                        </tr>
+                      <% end %>
+                    <% else %>
+                      <tr>
+                        <td colspan="<%= @can_manage_community_service ? 5 : 4 %>" class="px-6 py-4 text-center text-sm text-gray-500">
+                          <% if @current_season %>
+                            No community service records for this season
+                          <% else %>
+                            No current season configured
+                          <% end %>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <!-- Grade Cards (only for mentees) -->
+    <% if @user.mentee.present? %>
+      <div class="mt-6" data-controller="modal">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg leading-6 font-medium text-gray-900">
+            Grade Cards
+            <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @grade_cards&.count || 0 %></span>
+            <% if @current_season %>
+              <span class="ml-2 text-sm font-normal text-gray-500">(<%= @current_season.name %> Season)</span>
+            <% end %>
+          </h3>
+          <% if @can_upload_grade_cards %>
+            <button type="button"
+                  data-action="click->modal#open"
+              class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
+              + Add Grade Card
+            </button>
           <% end %>
-
-          <!-- New Guardian Modal -->
+        </div>
+        <!-- Add Grade Card Modal -->
+        <% if @can_upload_grade_cards %>
           <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
             <div data-modal-target="backdrop"
-                 data-action="click->modal#closeOnBackdrop"
-                 class="fixed inset-0 bg-black/50 transition-opacity"></div>
-
+               data-action="click->modal#closeOnBackdrop"
+              class="fixed inset-0 bg-black/50 transition-opacity"></div>
             <div class="fixed inset-0 z-10 overflow-y-auto">
               <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
                 <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                  <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                    <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Create New Guardian</h3>
-                    <p class="text-sm text-gray-500 mb-4">The guardian will receive an email to confirm their account and set a password.</p>
-
-                    <%= form_with url: create_guardian_user_path(@user), method: :post, class: "space-y-4", data: { turbo: false } do |f| %>
+                  <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4" data-controller="upload-form">
+                    <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Add Grade Card</h3>
+                    <p class="text-sm text-gray-500 mb-4">Upload an image of <%= @user.first_name %>'s grade card.</p>
+                    <%= form_with url: add_grade_card_user_path(@user), method: :post, multipart: true, class: "space-y-4", data: { upload_form_target: "form" } do |f| %>
                       <div>
-                        <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
-                        <%= f.email_field :email, required: true, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm", placeholder: "guardian@example.com" %>
+                        <%= label_tag :file, "Grade Card Image", class: "block text-sm font-medium text-gray-700" %>
+                        <%= file_field_tag :file, accept: "image/*", required: true, class: "mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" %>
+                        <p class="mt-1 text-xs text-gray-500">Accepted formats: JPG, PNG, GIF</p>
                       </div>
-
-                      <div class="grid grid-cols-2 gap-4">
-                        <div>
-                          <%= f.label :first_name, "First Name", class: "block text-sm font-medium text-gray-700" %>
-                          <%= f.text_field :first_name, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                        </div>
-                        <div>
-                          <%= f.label :last_name, "Last Name", class: "block text-sm font-medium text-gray-700" %>
-                          <%= f.text_field :last_name, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                        </div>
-                      </div>
-
                       <div>
-                        <%= f.label :relationship_type, "Relationship to Child", class: "block text-sm font-medium text-gray-700" %>
-                        <%= f.select :relationship_type, @allowed_relationship_types, {}, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                        <%= label_tag :description, "Description (optional)", class: "block text-sm font-medium text-gray-700" %>
+                        <%= text_field_tag :description, nil, placeholder: "e.g., Fall 2025 semester grades", class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
                       </div>
-
+                      <!-- Upload Progress -->
+                      <div data-upload-form-target="progress" class="hidden">
+                        <div class="w-full bg-gray-200 rounded-full h-2.5">
+                          <div data-upload-form-target="progressBar" class="bg-indigo-600 h-2.5 rounded-full transition-all duration-300" style="width: 0%"></div>
+                        </div>
+                        <p data-upload-form-target="progressText" class="mt-2 text-sm text-gray-600 text-center">Uploading...</p>
+                      </div>
                       <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                        <%= f.submit "Create Guardian", class: "inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:col-start-2 cursor-pointer" %>
+                        <%= f.submit "Upload Grade Card", data: { upload_form_target: "submit" }, class: "inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:col-start-2 cursor-pointer" %>
                         <button type="button"
-                                data-action="click->modal#close"
-                                class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
+                              data-action="click->modal#close"
+                          class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
                           Cancel
                         </button>
                       </div>
@@ -641,321 +949,46 @@
               </div>
             </div>
           </div>
-        </div>
-      <% end %>
-
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Guardian
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Relationship
-                    </th>
-                    <% if @can_manage_family_members %>
-                      <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Actions
-                      </th>
-                    <% end %>
-                  </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                  <% if @user.mentee.family_members.any? %>
-                    <% @user.mentee.family_members.includes(guardian: :user).each do |family_member| %>
-                      <tr>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <%= link_to family_member.guardian.user.email, user_path(family_member.guardian.user), class: "text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
-                          <div class="text-sm text-gray-500">
-                            <%= family_member.guardian.user.first_name %> <%= family_member.guardian.user.last_name %>
-                          </div>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                            <%= family_member.relationship_type.titleize %>
-                          </span>
-                        </td>
-                        <% if @can_manage_family_members %>
-                          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                            <%= button_to "Remove", remove_family_member_user_path(@user, family_member_id: family_member.id), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove this guardian?" } %>
-                          </td>
-                        <% end %>
-                      </tr>
-                    <% end %>
-                  <% else %>
-                    <tr>
-                      <td colspan="<%= @can_manage_family_members ? 3 : 2 %>" class="px-6 py-4 text-center text-sm text-gray-500">No guardians</td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <% end %>
-
-    <!-- Community Service (only for mentees) -->
-    <% if @user.mentee.present? %>
-    <div class="mt-6">
-      <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">
-          Community Service
-          <% if @current_season %>
-            <span class="ml-2 text-sm font-normal text-gray-500">(<%= @current_season.name %> Season)</span>
-          <% end %>
-        </h3>
-        <div class="text-right">
-          <div class="text-2xl font-bold text-pink-600"><%= @total_community_service_hours || 0 %></div>
-          <div class="text-xs text-gray-500">Total Hours</div>
-        </div>
-      </div>
-
-
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Activity
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Date
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Hours
-                    </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <% if @can_manage_community_service %>
-                      <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Actions
-                      </th>
-                    <% end %>
-                  </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                  <% if @community_service_records&.any? %>
-                    <% @community_service_records.each do |record| %>
-                      <tr data-controller="modal">
-                        <td class="px-6 py-4">
-                          <div class="text-sm font-medium text-gray-900"><%= record.event %></div>
-                          <% if record.description.present? %>
-                            <div class="text-sm text-gray-500 truncate max-w-xs"><%= record.description %></div>
-                          <% end %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          <%= record.event_date.strftime("%b %d, %Y") %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                          <%= record.hours %>
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                          <% if record.approved? %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                              Approved
-                            </span>
-                          <% else %>
-                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
-                              Denied
-                            </span>
-                          <% end %>
-                        </td>
-                        <% if @can_manage_community_service %>
-                          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                            <% if record.approved? %>
-                              <button type="button"
-                                      data-action="click->modal#open"
-                                      class="text-red-600 hover:text-red-900">
-                                Deny
-                              </button>
-
-                              <!-- Deny Modal -->
-                              <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
-                                <div data-modal-target="backdrop"
-                                     data-action="click->modal#closeOnBackdrop"
-                                     class="fixed inset-0 bg-black/50 transition-opacity"></div>
-
-                                <div class="fixed inset-0 z-10 overflow-y-auto">
-                                  <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-                                    <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                                      <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-                                        <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Deny Community Service Record</h3>
-                                        <p class="text-sm text-gray-500 mb-4">
-                                          You are denying <strong><%= record.event %></strong> (<%= number_with_precision(record.hours, precision: 1) %> hours) for <%= @user.first_name %> <%= @user.last_name %>.
-                                        </p>
-
-                                        <%= form_with url: community_service_record_path(record), method: :patch, class: "space-y-4" do |f| %>
-                                          <%= hidden_field_tag :redirect_to, user_path(@user) %>
-                                          <input type="hidden" name="community_service_record[approved]" value="false">
-
-                                          <div>
-                                            <%= label_tag :denial_reason, "Reason for denial", class: "block text-sm font-medium text-gray-700" %>
-                                            <%= text_area_tag :denial_reason, nil, rows: 3, required: true, class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm", placeholder: "Please explain why this record is being denied..." %>
-                                            <p class="mt-1 text-xs text-gray-500">This message will be sent to <%= @user.first_name %>.</p>
-                                          </div>
-
-                                          <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                                            <%= f.submit "Deny Record", class: "inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:col-start-2 cursor-pointer" %>
-                                            <button type="button"
-                                                    data-action="click->modal#close"
-                                                    class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
-                                              Cancel
-                                            </button>
-                                          </div>
-                                        <% end %>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            <% else %>
-                              <%= button_to "Approve", community_service_record_path(record), method: :patch, params: { community_service_record: { approved: true }, redirect_to: user_path(@user) }, class: "text-green-600 hover:text-green-900" %>
-                            <% end %>
-                          </td>
-                        <% end %>
-                      </tr>
-                    <% end %>
-                  <% else %>
-                    <tr>
-                      <td colspan="<%= @can_manage_community_service ? 5 : 4 %>" class="px-6 py-4 text-center text-sm text-gray-500">
-                        <% if @current_season %>
-                          No community service records for this season
-                        <% else %>
-                          No current season configured
-                        <% end %>
-                      </td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <% end %>
-
-    <!-- Grade Cards (only for mentees) -->
-    <% if @user.mentee.present? %>
-    <div class="mt-6" data-controller="modal">
-      <div class="flex justify-between items-center mb-4">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">
-          Grade Cards
-          <span class="ml-2 px-2 py-0.5 text-sm font-normal text-gray-600 bg-gray-100 rounded-full"><%= @grade_cards&.count || 0 %></span>
-          <% if @current_season %>
-            <span class="ml-2 text-sm font-normal text-gray-500">(<%= @current_season.name %> Season)</span>
-          <% end %>
-        </h3>
-        <% if @can_upload_grade_cards %>
-          <button type="button"
-                  data-action="click->modal#open"
-                  class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700">
-            + Add Grade Card
-          </button>
         <% end %>
-      </div>
-
-      <!-- Add Grade Card Modal -->
-      <% if @can_upload_grade_cards %>
-        <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
-          <div data-modal-target="backdrop"
-               data-action="click->modal#closeOnBackdrop"
-               class="fixed inset-0 bg-black/50 transition-opacity"></div>
-
-          <div class="fixed inset-0 z-10 overflow-y-auto">
-            <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-              <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4" data-controller="upload-form">
-                  <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">Add Grade Card</h3>
-                  <p class="text-sm text-gray-500 mb-4">Upload an image of <%= @user.first_name %>'s grade card.</p>
-
-                  <%= form_with url: add_grade_card_user_path(@user), method: :post, multipart: true, class: "space-y-4", data: { upload_form_target: "form" } do |f| %>
-                    <div>
-                      <%= label_tag :file, "Grade Card Image", class: "block text-sm font-medium text-gray-700" %>
-                      <%= file_field_tag :file, accept: "image/*", required: true, class: "mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" %>
-                      <p class="mt-1 text-xs text-gray-500">Accepted formats: JPG, PNG, GIF</p>
-                    </div>
-
-                    <div>
-                      <%= label_tag :description, "Description (optional)", class: "block text-sm font-medium text-gray-700" %>
-                      <%= text_field_tag :description, nil, placeholder: "e.g., Fall 2025 semester grades", class: "mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                    </div>
-
-                    <!-- Upload Progress -->
-                    <div data-upload-form-target="progress" class="hidden">
-                      <div class="w-full bg-gray-200 rounded-full h-2.5">
-                        <div data-upload-form-target="progressBar" class="bg-indigo-600 h-2.5 rounded-full transition-all duration-300" style="width: 0%"></div>
-                      </div>
-                      <p data-upload-form-target="progressText" class="mt-2 text-sm text-gray-600 text-center">Uploading...</p>
-                    </div>
-
-                    <div class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
-                      <%= f.submit "Upload Grade Card", data: { upload_form_target: "submit" }, class: "inline-flex w-full justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:col-start-2 cursor-pointer" %>
-                      <button type="button"
-                              data-action="click->modal#close"
-                              class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0">
-                        Cancel
-                      </button>
-                    </div>
+        <!-- Grade Cards Grid -->
+        <% if @grade_cards&.any? %>
+          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            <% @grade_cards.each do |grade_card| %>
+              <div class="bg-white shadow sm:rounded-lg overflow-hidden" data-controller="modal">
+                <button type="button" data-action="click->modal#open" class="w-full focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                  <img src="<%= grade_card.thumbnail_url %>" alt="Grade card" class="w-full h-40 object-cover">
+                </button>
+                <div class="p-3">
+                  <% if grade_card.description.present? %>
+                    <p class="text-sm text-gray-900 truncate"><%= grade_card.description %></p>
                   <% end %>
+                  <p class="text-xs text-gray-500 mt-1"><%= grade_card.created_at.strftime("%b %d, %Y") %></p>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <!-- Grade Cards Grid -->
-      <% if @grade_cards&.any? %>
-        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          <% @grade_cards.each do |grade_card| %>
-            <div class="bg-white shadow sm:rounded-lg overflow-hidden" data-controller="modal">
-              <button type="button" data-action="click->modal#open" class="w-full focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                <img src="<%= grade_card.thumbnail_url %>" alt="Grade card" class="w-full h-40 object-cover">
-              </button>
-              <div class="p-3">
-                <% if grade_card.description.present? %>
-                  <p class="text-sm text-gray-900 truncate"><%= grade_card.description %></p>
-                <% end %>
-                <p class="text-xs text-gray-500 mt-1"><%= grade_card.created_at.strftime("%b %d, %Y") %></p>
-              </div>
-
-              <!-- Full Size Modal -->
-              <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
-                <div data-modal-target="backdrop"
+                <!-- Full Size Modal -->
+                <div data-modal-target="dialog" class="hidden fixed inset-0 z-50">
+                  <div data-modal-target="backdrop"
                      data-action="click->modal#closeOnBackdrop"
-                     class="fixed inset-0 bg-black/75 transition-opacity"></div>
-
-                <div class="fixed inset-0 z-10 overflow-y-auto">
-                  <div class="flex min-h-full items-center justify-center p-4">
-                    <div class="relative transform overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:max-w-3xl w-full">
-                      <div class="bg-white">
-                        <img src="<%= grade_card.url %>" alt="Grade card" class="w-full">
-                        <div class="p-4 border-t">
-                          <% if grade_card.description.present? %>
-                            <p class="text-sm text-gray-900"><%= grade_card.description %></p>
-                          <% end %>
-                          <p class="text-xs text-gray-500 mt-1">Uploaded <%= grade_card.created_at.strftime("%B %d, %Y at %I:%M %p") %></p>
-
-                          <div class="mt-4 flex justify-end space-x-3">
-                            <% if @can_delete_grade_cards %>
-                              <%= button_to "Delete", remove_grade_card_user_path(@user, grade_card_id: grade_card.id), method: :delete, class: "inline-flex justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500", data: { turbo_confirm: "Are you sure you want to delete this grade card?" } %>
+                    class="fixed inset-0 bg-black/75 transition-opacity"></div>
+                  <div class="fixed inset-0 z-10 overflow-y-auto">
+                    <div class="flex min-h-full items-center justify-center p-4">
+                      <div class="relative transform overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:max-w-3xl w-full">
+                        <div class="bg-white">
+                          <img src="<%= grade_card.url %>" alt="Grade card" class="w-full">
+                          <div class="p-4 border-t">
+                            <% if grade_card.description.present? %>
+                              <p class="text-sm text-gray-900"><%= grade_card.description %></p>
                             <% end %>
-                            <button type="button"
+                            <p class="text-xs text-gray-500 mt-1">Uploaded <%= grade_card.created_at.strftime("%B %d, %Y at %I:%M %p") %></p>
+                            <div class="mt-4 flex justify-end space-x-3">
+                              <% if @can_delete_grade_cards %>
+                                <%= button_to "Delete", remove_grade_card_user_path(@user, grade_card_id: grade_card.id), method: :delete, class: "inline-flex justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500", data: { turbo_confirm: "Are you sure you want to delete this grade card?" } %>
+                              <% end %>
+                              <button type="button"
                                     data-action="click->modal#close"
-                                    class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                              Close
-                            </button>
+                                class="inline-flex justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+                                Close
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -963,23 +996,21 @@
                   </div>
                 </div>
               </div>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <div class="bg-white shadow sm:rounded-lg p-6 text-center">
-          <p class="text-sm text-gray-500">
-            <% if @current_season %>
-              No grade cards uploaded for this season
-            <% else %>
-              No grade cards uploaded
             <% end %>
-          </p>
-        </div>
-      <% end %>
-    </div>
+          </div>
+        <% else %>
+          <div class="bg-white shadow sm:rounded-lg p-6 text-center">
+            <p class="text-sm text-gray-500">
+              <% if @current_season %>
+                No grade cards uploaded for this season
+              <% else %>
+                No grade cards uploaded
+              <% end %>
+            </p>
+          </div>
+        <% end %>
+      </div>
     <% end %>
-
     <!-- Event Attendance -->
     <div class="mt-6">
       <div class="flex justify-between items-center mb-4">
@@ -998,7 +1029,6 @@
           </div>
         <% end %>
       </div>
-
       <!-- Add Event Log Form -->
       <% if @can_manage_event_logs && @available_events&.any? %>
         <div class="mb-4 bg-white shadow sm:rounded-lg p-4">
@@ -1022,7 +1052,6 @@
           <p class="text-sm text-gray-500">No more events available to add for this season.</p>
         </div>
       <% end %>
-
       <div class="flex flex-col">
         <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
           <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
       post :redeem_incentive
       post :deny_redemption
       delete :delete_redemption
+      get :point_history
+      post :adjust_points
     end
   end
 

--- a/db/migrate/20260329214924_create_point_logs.rb
+++ b/db/migrate/20260329214924_create_point_logs.rb
@@ -1,0 +1,17 @@
+class CreatePointLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :point_logs do |t|
+      t.references :mentee, null: false, foreign_key: true
+      t.integer :points, null: false
+      t.string :log_type, null: false, default: "adjustment"
+      t.string :reason, null: false
+      t.references :source, polymorphic: true
+      t.references :awarded_by, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :point_logs, [:mentee_id, :created_at], order: { created_at: :desc }
+    add_index :point_logs, :log_type
+  end
+end

--- a/db/migrate/20260329215226_backfill_point_logs.rb
+++ b/db/migrate/20260329215226_backfill_point_logs.rb
@@ -1,0 +1,68 @@
+class BackfillPointLogs < ActiveRecord::Migration[8.1]
+  def up
+    # Backfill attendance points from event_logs
+    # Only for mentees who arrived at events (log_type = 'arrived')
+    EventLog.where(log_type: "arrived").where("points_awarded > 0").find_each do |event_log|
+      mentee = event_log.user.mentee
+      next unless mentee.present?
+
+      PointLog.create!(
+        mentee: mentee,
+        points: event_log.points_awarded,
+        reason: "Attended #{event_log.event.name} on #{event_log.event.event_date.strftime("%B %d, %Y")}",
+        awarded_by: nil, # Historical data - no specific user awarded these
+        log_type: "attendance",
+        source: event_log,
+        created_at: event_log.created_at
+      )
+    end
+
+    # Backfill redemption deductions from redemptions
+    # For pending, approved, and deleted_no_refund statuses
+    Redemption.where(status: ["pending", "approved", "deleted_no_refund"]).find_each do |redemption|
+      PointLog.create!(
+        mentee: redemption.mentee,
+        points: -redemption.points_spent,
+        reason: "Redeemed: #{redemption.incentive.name}",
+        awarded_by: redemption.approved_by, # May be nil for pending redemptions
+        log_type: "redemption",
+        source: redemption,
+        created_at: redemption.created_at
+      )
+    end
+
+    # Backfill refunds for deleted redemptions
+    Redemption.where(status: "deleted").find_each do |redemption|
+      # First create the redemption deduction
+      PointLog.create!(
+        mentee: redemption.mentee,
+        points: -redemption.points_spent,
+        reason: "Redeemed: #{redemption.incentive.name}",
+        awarded_by: redemption.approved_by, # May be nil for pending redemptions
+        log_type: "redemption",
+        source: redemption,
+        created_at: redemption.created_at
+      )
+
+      # Then create the refund adjustment
+      PointLog.create!(
+        mentee: redemption.mentee,
+        points: redemption.points_spent,
+        reason: "Refund for deleted redemption: #{redemption.incentive.name}",
+        awarded_by: nil, # Historical data - no specific user awarded these
+        log_type: "adjustment",
+        source: redemption,
+        created_at: redemption.updated_at
+      )
+    end
+  end
+
+  def down
+    # Remove all point logs with log_type 'attendance' that have event_logs as source
+    # and all point logs with log_type 'redemption' or 'adjustment' that have redemptions as source
+    execute <<-SQL.squish
+      DELETE FROM point_logs
+      WHERE source_type IN ('EventLog', 'Redemption')
+    SQL
+  end
+end

--- a/db/migrate/20260329215807_make_point_logs_awarded_by_nullable.rb
+++ b/db/migrate/20260329215807_make_point_logs_awarded_by_nullable.rb
@@ -1,0 +1,5 @@
+class MakePointLogsAwardedByNullable < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :point_logs, :awarded_by_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_28_020109) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_29_215807) do
   create_table "community_service_records", force: :cascade do |t|
     t.boolean "approved", default: true, null: false
     t.datetime "created_at", null: false
@@ -178,6 +178,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_020109) do
     t.integer "start_day", null: false
     t.integer "start_month", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "point_logs", force: :cascade do |t|
+    t.integer "awarded_by_id"
+    t.datetime "created_at", null: false
+    t.string "log_type", default: "adjustment", null: false
+    t.integer "mentee_id", null: false
+    t.integer "points", null: false
+    t.string "reason", null: false
+    t.integer "source_id"
+    t.string "source_type"
+    t.datetime "updated_at", null: false
+    t.index ["awarded_by_id"], name: "index_point_logs_on_awarded_by_id"
+    t.index ["log_type"], name: "index_point_logs_on_log_type"
+    t.index ["mentee_id", "created_at"], name: "index_point_logs_on_mentee_id_and_created_at", order: { created_at: :desc }
+    t.index ["mentee_id"], name: "index_point_logs_on_mentee_id"
+    t.index ["source_type", "source_id"], name: "index_point_logs_on_source"
   end
 
   create_table "redemptions", force: :cascade do |t|
@@ -366,6 +383,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_020109) do
   add_foreign_key "message_recipients", "users", column: "recipient_id"
   add_foreign_key "messages", "messages", column: "parent_id"
   add_foreign_key "messages", "users", column: "author_id"
+  add_foreign_key "point_logs", "mentees"
+  add_foreign_key "point_logs", "users", column: "awarded_by_id"
   add_foreign_key "redemptions", "incentives"
   add_foreign_key "redemptions", "mentees"
   add_foreign_key "redemptions", "users", column: "approved_by_id"

--- a/test/controllers/rewards_controller_test.rb
+++ b/test/controllers/rewards_controller_test.rb
@@ -105,7 +105,7 @@ class RewardsControllerTest < ActionDispatch::IntegrationTest
     )
     event_type = EventType.create!(name: "Test Event", category: "org", point_value: 50)
     event = Event.create!(name: "Points Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50, log_type: "arrived")
 
     login_as(@mentee_user)
     get rewards_path

--- a/test/controllers/users_controller_redemptions_test.rb
+++ b/test/controllers/users_controller_redemptions_test.rb
@@ -19,7 +19,7 @@ class UsersControllerRedemptionsTest < ActionDispatch::IntegrationTest
     )
     event_type = EventType.create!(name: "Test Event", category: "org", point_value: 100)
     event = Event.create!(name: "Points Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100, log_type: "arrived")
 
     @incentive = Incentive.create!(
       name: "Jack Stack Gift Card",

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -600,4 +600,207 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil @staff_user.confirmation_token
     assert_not_nil @staff_user.confirmation_sent_at
   end
+
+  # Point History Tests
+  test "point history requires authentication" do
+    mentee_user = User.create!(email: "mentee_test@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    get point_history_user_path(mentee_user)
+    assert_redirected_to root_path
+  end
+
+  test "point history requires user to be a mentee" do
+    login_as(@user)
+
+    get point_history_user_path(@staff_user)
+    assert_redirected_to user_path(@staff_user)
+    assert_equal "User is not a mentee", flash[:alert]
+  end
+
+  test "point history requires manage_points permission" do
+    mentor_user = User.create!(email: "mentor_test@example.com", password: "Password123!")
+    Mentor.create!(user: mentor_user)
+    mentor_user.activate!
+
+    mentee_user = User.create!(email: "mentee_ph@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    login_as(mentor_user)
+
+    get point_history_user_path(mentee_user)
+    assert_redirected_to user_path(mentee_user)
+    assert_equal "You don't have permission to manage points", flash[:alert]
+  end
+
+  test "point history displays successfully for admin" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_ph2@example.com", password: "Password123!")
+    mentee = Mentee.create!(user: mentee_user)
+
+    # Create some point logs
+    PointLog.create!(mentee: mentee, points: 10, reason: "Test", awarded_by: @user, log_type: "attendance")
+    PointLog.create!(mentee: mentee, points: -5, reason: "Test", awarded_by: @user, log_type: "redemption")
+
+    get point_history_user_path(mentee_user)
+    assert_response :success
+    assert_select "h3", "Points History"
+  end
+
+  test "point history displays successfully for staff" do
+    login_as(@staff_user)
+
+    mentee_user = User.create!(email: "mentee_ph3@example.com", password: "Password123!")
+    mentee = Mentee.create!(user: mentee_user)
+
+    PointLog.create!(mentee: mentee, points: 15, reason: "Test", awarded_by: @staff_user, log_type: "adjustment")
+
+    get point_history_user_path(mentee_user)
+    assert_response :success
+  end
+
+  # Adjust Points Tests
+  test "adjust points requires authentication" do
+    mentee_user = User.create!(email: "mentee_adj@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    post adjust_points_user_path(mentee_user), params: { points: 10, reason: "Test" }
+    assert_redirected_to root_path
+  end
+
+  test "adjust points requires user to be a mentee" do
+    login_as(@user)
+
+    post adjust_points_user_path(@staff_user), params: { points: 10, reason: "Test" }
+    assert_redirected_to user_path(@staff_user)
+    assert_equal "User is not a mentee", flash[:alert]
+  end
+
+  test "adjust points requires manage_points permission" do
+    mentor_user = User.create!(email: "mentor_adj@example.com", password: "Password123!")
+    Mentor.create!(user: mentor_user)
+    mentor_user.activate!
+
+    mentee_user = User.create!(email: "mentee_adj2@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    login_as(mentor_user)
+
+    post adjust_points_user_path(mentee_user), params: { points: 10, reason: "Test" }
+    assert_redirected_to user_path(mentee_user)
+    assert_equal "You don't have permission to manage points", flash[:alert]
+  end
+
+  test "adjust points requires non-zero adjustment" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj3@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    post adjust_points_user_path(mentee_user), params: { points: 0, reason: "Test" }
+    assert_redirected_to user_path(mentee_user)
+    assert_equal "Points adjustment must not be zero", flash[:alert]
+  end
+
+  test "adjust points requires reason" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj4@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    post adjust_points_user_path(mentee_user), params: { points: 10, reason: "" }
+    assert_redirected_to user_path(mentee_user)
+    assert_equal "Reason is required", flash[:alert]
+  end
+
+  test "adjust points cannot reduce below zero" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj5@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+
+    # Mentee has 0 points
+    post adjust_points_user_path(mentee_user), params: { points: -10, reason: "Test" }
+    assert_redirected_to user_path(mentee_user)
+    assert_match(/Cannot reduce points below zero/, flash[:alert])
+  end
+
+  test "adjust points successfully adds points" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj6@example.com", password: "Password123!")
+    mentee = Mentee.create!(user: mentee_user)
+
+    # Create a season for point calculations
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    assert_difference "PointLog.count", 1 do
+      post adjust_points_user_path(mentee_user), params: { points: 10, reason: "Good behavior" }
+    end
+
+    assert_redirected_to user_path(mentee_user)
+    assert_match(/Points adjusted successfully/, flash[:notice])
+
+    mentee.reload
+    assert_equal 10, mentee.total_points
+  end
+
+  test "adjust points successfully deducts points" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj7@example.com", password: "Password123!")
+    mentee = Mentee.create!(user: mentee_user)
+
+    # Create a season for point calculations
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    # Give mentee some points first
+    PointLog.create!(mentee: mentee, points: 20, reason: "Initial", awarded_by: @user, log_type: "adjustment")
+
+    assert_difference "PointLog.count", 1 do
+      post adjust_points_user_path(mentee_user), params: { points: -5, reason: "Correction" }
+    end
+
+    assert_redirected_to user_path(mentee_user)
+    assert_match(/Points adjusted successfully/, flash[:notice])
+
+    mentee.reload
+    assert_equal 15, mentee.total_points
+  end
+
+  test "adjust points sends message when requested" do
+    login_as(@user)
+
+    mentee_user = User.create!(email: "mentee_adj8@example.com", password: "Password123!")
+    Mentee.create!(user: mentee_user)
+    mentee_user.activate!
+
+    assert_difference "PointLog.count", 1 do
+      assert_difference "Message.count", 1 do
+        post adjust_points_user_path(mentee_user), params: {
+          points: 10,
+          reason: "Good job!",
+          send_message: "1",
+          message_text: "Keep up the great work!"
+        }
+      end
+    end
+
+    assert_redirected_to user_path(mentee_user)
+  end
 end

--- a/test/graphql/mutations/redemptions_test.rb
+++ b/test/graphql/mutations/redemptions_test.rb
@@ -29,7 +29,7 @@ class RedemptionsMutationsTest < ActiveSupport::TestCase
 
     event_type = EventType.create!(name: "GQL Event Type", category: "org", point_value: 50)
     event = Event.create!(name: "GQL Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50, log_type: "arrived")
   end
 
   CREATE_REDEMPTION = <<~GQL

--- a/test/graphql/queries/rewards_test.rb
+++ b/test/graphql/queries/rewards_test.rb
@@ -45,7 +45,7 @@ class RewardsQueryTest < ActiveSupport::TestCase
 
     event_type = EventType.create!(name: "Rewards Event Type", category: "org", point_value: 50)
     event = Event.create!(name: "Rewards Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50, log_type: "arrived")
 
     # Create some redemptions
     @pending = Redemption.create!(mentee: @mentee, incentive: @individual_incentive, points_spent: 25, status: "pending")
@@ -100,7 +100,7 @@ class RewardsQueryTest < ActiveSupport::TestCase
     result = execute_graphql(REWARDS_QUERY, context: { current_user: @mentee_user })
 
     all_names = result.dig("data", "rewards", "individualIncentives").map { |i| i["name"] } +
-                result.dig("data", "rewards", "teamIncentives").map { |i| i["name"] }
+      result.dig("data", "rewards", "teamIncentives").map { |i| i["name"] }
     assert_not_includes all_names, "Inactive Reward"
   end
 

--- a/test/messages/redemption_created_message_test.rb
+++ b/test/messages/redemption_created_message_test.rb
@@ -104,7 +104,7 @@ class RedemptionCreatedMessageTest < ActiveSupport::TestCase
     )
     event_type = EventType.create!(name: "Point Event", category: "org", point_value: 100)
     event = Event.create!(name: "Points Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100, log_type: "arrived")
 
     # Create a new redemption (the setup one already exists and deducts 25 points)
     # With 100 points earned - 25 points spent (from setup redemption) = 75 points

--- a/test/models/event_log_point_log_integration_test.rb
+++ b/test/models/event_log_point_log_integration_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class EventLogPointLogIntegrationTest < ActiveSupport::TestCase
+  def setup
+    @admin = create_user(email: "admin_event_log@example.com")
+    @mentee_user = create_mentee_user(email: "mentee_event_log@example.com")
+    @mentee = @mentee_user.mentee
+
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    @event_type = EventType.create!(name: "Test Event", category: "org", point_value: 50)
+    @event = Event.create!(name: "Test Event", event_date: Time.current, event_type: @event_type, created_by: @admin)
+  end
+
+  test "event log with arrived status creates point log" do
+    assert_difference "PointLog.count", 1 do
+      EventLog.create!(
+        user: @mentee_user,
+        event: @event,
+        points_awarded: 50,
+        log_type: "arrived"
+      )
+    end
+
+    @mentee.reload
+    assert_equal 50, @mentee.total_points
+  end
+
+  test "event log without arrived status does not create point log" do
+    assert_no_difference "PointLog.count" do
+      EventLog.create!(
+        user: @mentee_user,
+        event: @event,
+        points_awarded: 50
+        # log_type defaults to "registered"
+      )
+    end
+
+    @mentee.reload
+    assert_equal 0, @mentee.total_points
+  end
+end

--- a/test/models/mentee_test.rb
+++ b/test/models/mentee_test.rb
@@ -33,6 +33,10 @@ class MenteeTest < ActiveSupport::TestCase
     assert_respond_to @mentee, :guardians
   end
 
+  test "has many point_logs" do
+    assert_respond_to @mentee, :point_logs
+  end
+
   # Validations
   test "is valid with a user" do
     assert @mentee.valid?
@@ -93,7 +97,7 @@ class MenteeTest < ActiveSupport::TestCase
   end
 
   # Total points
-  test "total_points returns 0 when no event logs exist" do
+  test "total_points returns 0 when no point logs exist" do
     @mentee.save!
     assert_equal 0, @mentee.total_points
   end
@@ -105,7 +109,7 @@ class MenteeTest < ActiveSupport::TestCase
     assert_equal 0, @mentee.total_points
   end
 
-  test "total_points sums points from event logs within current season" do
+  test "total_points sums points from point logs within current season" do
     @mentee.save!
 
     # Create a current season (month/day based)
@@ -118,22 +122,16 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Test Event Type", category: "org", point_value: 10)
-    event = Event.create!(
-      name: "Test Event",
-      event_date: Time.current,
-      event_type: event_type,
-      created_by: @user
-    )
+    admin_user = create_user(email: "admin@test.com")
 
-    # Create event logs for this mentee's user
-    EventLog.create!(user: @user, event: event, points_awarded: 10)
-    EventLog.create!(user: @user, event: event, points_awarded: 5)
+    # Create point logs for this mentee within season
+    PointLog.create!(mentee: @mentee, points: 10, reason: "Event 1", awarded_by: admin_user, log_type: "attendance")
+    PointLog.create!(mentee: @mentee, points: 5, reason: "Event 2", awarded_by: admin_user, log_type: "attendance")
 
     assert_equal 15, @mentee.total_points
   end
 
-  test "total_points excludes points from events outside current season" do
+  test "total_points excludes points from point logs outside current season" do
     @mentee.save!
 
     # Create a current season (month/day based)
@@ -146,26 +144,13 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Test Event Type", category: "org", point_value: 10)
+    admin_user = create_user(email: "admin@test.com")
 
-    # Event within season
-    current_event = Event.create!(
-      name: "Current Event",
-      event_date: Time.current,
-      event_type: event_type,
-      created_by: @user
-    )
+    # Point log within season
+    PointLog.create!(mentee: @mentee, points: 10, reason: "Current", awarded_by: admin_user, log_type: "attendance")
 
-    # Event outside season
-    old_event = Event.create!(
-      name: "Old Event",
-      event_date: 3.months.ago,
-      event_type: event_type,
-      created_by: @user
-    )
-
-    EventLog.create!(user: @user, event: current_event, points_awarded: 10)
-    EventLog.create!(user: @user, event: old_event, points_awarded: 100)
+    # Point log outside season
+    PointLog.create!(mentee: @mentee, points: 100, reason: "Old", awarded_by: admin_user, log_type: "attendance", created_at: 3.months.ago)
 
     assert_equal 10, @mentee.total_points
   end
@@ -173,24 +158,10 @@ class MenteeTest < ActiveSupport::TestCase
   test "total_points accepts custom date range" do
     @mentee.save!
 
-    event_type = EventType.create!(name: "Test Event Type", category: "org", point_value: 10)
+    admin_user = create_user(email: "admin@test.com")
 
-    event1 = Event.create!(
-      name: "Event 1",
-      event_date: 2.days.ago,
-      event_type: event_type,
-      created_by: @user
-    )
-
-    event2 = Event.create!(
-      name: "Event 2",
-      event_date: 10.days.ago,
-      event_type: event_type,
-      created_by: @user
-    )
-
-    EventLog.create!(user: @user, event: event1, points_awarded: 5)
-    EventLog.create!(user: @user, event: event2, points_awarded: 20)
+    PointLog.create!(mentee: @mentee, points: 5, reason: "Recent", awarded_by: admin_user, log_type: "attendance", created_at: 2.days.ago)
+    PointLog.create!(mentee: @mentee, points: 20, reason: "Older", awarded_by: admin_user, log_type: "attendance", created_at: 10.days.ago)
 
     # Only include last week
     week_range = 1.week.ago..Time.current
@@ -211,12 +182,11 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
 
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 20, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 20, status: "pending")
+    # Spend 20 points on pending redemption
+    PointLog.create!(mentee: @mentee, points: -20, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
 
     assert_equal 30, @mentee.total_points
   end
@@ -234,86 +204,16 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
 
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 20, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 20, status: "approved", approved_by: admin)
-
-    assert_equal 30, @mentee.total_points
-  end
-
-  test "total_points restores points for denied redemptions" do
-    @mentee.save!
-    admin = create_user(email: "pts_admin@example.com")
-
-    today = Date.current
-    OlympicSeason.create!(
-      name: "Test Season",
-      start_month: (today - 1.month).month,
-      start_day: (today - 1.month).day,
-      end_month: (today + 1.month).month,
-      end_day: (today + 1.month).day
-    )
-
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
-
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 20, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 20, status: "denied")
-
-    assert_equal 50, @mentee.total_points
-  end
-
-  test "total_points restores points for deleted (refunded) redemptions" do
-    @mentee.save!
-    admin = create_user(email: "pts_admin@example.com")
-
-    today = Date.current
-    OlympicSeason.create!(
-      name: "Test Season",
-      start_month: (today - 1.month).month,
-      start_day: (today - 1.month).day,
-      end_month: (today + 1.month).month,
-      end_day: (today + 1.month).day
-    )
-
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
-
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 20, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 20, status: "deleted")
-
-    assert_equal 50, @mentee.total_points
-  end
-
-  test "total_points keeps points deducted for deleted_no_refund redemptions" do
-    @mentee.save!
-    admin = create_user(email: "pts_admin@example.com")
-
-    today = Date.current
-    OlympicSeason.create!(
-      name: "Test Season",
-      start_month: (today - 1.month).month,
-      start_day: (today - 1.month).day,
-      end_month: (today + 1.month).month,
-      end_day: (today + 1.month).day
-    )
-
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
-
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 20, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 20, status: "deleted_no_refund")
+    # Spend 20 points on approved redemption
+    PointLog.create!(mentee: @mentee, points: -20, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
 
     assert_equal 30, @mentee.total_points
   end
 
-  test "total_points deducts multiple active redemptions" do
+  test "total_points does not deduct for denied redemptions when refunded" do
     @mentee.save!
     admin = create_user(email: "pts_admin@example.com")
 
@@ -326,14 +226,82 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
 
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 10, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 10, status: "pending")
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 10, status: "approved")
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 10, status: "denied")
+    # Redemption was denied and points refunded
+    PointLog.create!(mentee: @mentee, points: -20, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
+    PointLog.create!(mentee: @mentee, points: 20, reason: "Refund for denied redemption", awarded_by: admin, log_type: "adjustment")
+
+    assert_equal 50, @mentee.total_points
+  end
+
+  test "total_points handles deleted redemptions with refund" do
+    @mentee.save!
+    admin = create_user(email: "pts_admin@example.com")
+
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
+
+    # Spend and then refund
+    PointLog.create!(mentee: @mentee, points: -20, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
+    PointLog.create!(mentee: @mentee, points: 20, reason: "Refund for deleted redemption", awarded_by: admin, log_type: "adjustment")
+
+    assert_equal 50, @mentee.total_points
+  end
+
+  test "total_points handles deleted redemptions without refund" do
+    @mentee.save!
+    admin = create_user(email: "pts_admin@example.com")
+
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
+
+    # Spend without refund
+    PointLog.create!(mentee: @mentee, points: -20, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
+
+    assert_equal 30, @mentee.total_points
+  end
+
+  test "total_points handles multiple redemptions and adjustments" do
+    @mentee.save!
+    admin = create_user(email: "pts_admin@example.com")
+
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+
+    # Earn 50 points
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
+
+    # Multiple redemptions
+    PointLog.create!(mentee: @mentee, points: -10, reason: "Gift Card 1", awarded_by: admin, log_type: "redemption")
+    PointLog.create!(mentee: @mentee, points: -10, reason: "Gift Card 2", awarded_by: admin, log_type: "redemption")
+    PointLog.create!(mentee: @mentee, points: -10, reason: "Gift Card 3 - Denied", awarded_by: admin, log_type: "redemption")
+    PointLog.create!(mentee: @mentee, points: 10, reason: "Refund for denied", awarded_by: admin, log_type: "adjustment")
 
     assert_equal 30, @mentee.total_points
   end
@@ -423,7 +391,7 @@ class MenteeTest < ActiveSupport::TestCase
   # can_afford? tests
   test "can_afford? returns true when mentee has sufficient points" do
     @mentee.save!
-    create_user(email: "afford_admin@example.com")
+    admin = create_user(email: "afford_admin@example.com")
 
     today = Date.current
     OlympicSeason.create!(
@@ -434,9 +402,7 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
 
     assert @mentee.can_afford?(30)
   end
@@ -454,19 +420,15 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
-
-    incentive = Incentive.create!(name: "Gift Card", point_cost: 30, created_by: admin)
-    Redemption.create!(mentee: @mentee, incentive: incentive, points_spent: 30, status: "approved", approved_by: admin)
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
+    PointLog.create!(mentee: @mentee, points: -30, reason: "Gift Card", awarded_by: admin, log_type: "redemption")
 
     assert_not @mentee.can_afford?(25)
   end
 
   test "can_afford? returns true when mentee has exactly enough points" do
     @mentee.save!
-    create_user(email: "afford_admin3@example.com")
+    admin = create_user(email: "afford_admin3@example.com")
 
     today = Date.current
     OlympicSeason.create!(
@@ -477,9 +439,7 @@ class MenteeTest < ActiveSupport::TestCase
       end_day: (today + 1.month).day
     )
 
-    event_type = EventType.create!(name: "Point Event", category: "org", point_value: 50)
-    event = Event.create!(name: "Big Event", event_date: Time.current, event_type: event_type, created_by: @user)
-    EventLog.create!(user: @user, event: event, points_awarded: 50)
+    PointLog.create!(mentee: @mentee, points: 50, reason: "Event", awarded_by: admin, log_type: "attendance")
 
     assert @mentee.can_afford?(50)
   end

--- a/test/models/point_log_test.rb
+++ b/test/models/point_log_test.rb
@@ -1,0 +1,222 @@
+require "test_helper"
+
+class PointLogTest < ActiveSupport::TestCase
+  def setup
+    @mentee_user = User.create!(
+      email: "mentee@example.com",
+      password: "Password123!"
+    )
+    @mentee = Mentee.create!(user: @mentee_user)
+
+    @staff_user = User.create!(
+      email: "staff@example.com",
+      password: "Password123!"
+    )
+    Staff.create!(user: @staff_user)
+  end
+
+  # Associations
+  test "belongs to mentee" do
+    point_log = PointLog.new(mentee: @mentee, points: 10, reason: "Test", awarded_by: @staff_user, log_type: "adjustment")
+    assert_respond_to point_log, :mentee
+    assert_equal @mentee, point_log.mentee
+  end
+
+  test "belongs to awarded_by (User)" do
+    point_log = PointLog.new(mentee: @mentee, points: 10, reason: "Test", awarded_by: @staff_user, log_type: "adjustment")
+    assert_respond_to point_log, :awarded_by
+    assert_equal @staff_user, point_log.awarded_by
+  end
+
+  # Validations
+  test "is valid with all required attributes" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Test reason",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  test "is invalid without a mentee" do
+    point_log = PointLog.new(
+      mentee: nil,
+      points: 10,
+      reason: "Test reason",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert_not point_log.valid?
+    assert_includes point_log.errors[:mentee], "must exist"
+  end
+
+  test "is invalid without points" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: nil,
+      reason: "Test reason",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert_not point_log.valid?
+    assert_includes point_log.errors[:points], "can't be blank"
+  end
+
+  test "is invalid without a reason" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: nil,
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert_not point_log.valid?
+    assert_includes point_log.errors[:reason], "can't be blank"
+  end
+
+  test "is valid without an awarded_by" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Test reason",
+      awarded_by: nil,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  test "is invalid without a log_type" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Test reason",
+      awarded_by: @staff_user,
+      log_type: nil
+    )
+    assert_not point_log.valid?
+    assert_includes point_log.errors[:log_type], "can't be blank"
+  end
+
+  test "is invalid with an invalid log_type" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Test reason",
+      awarded_by: @staff_user,
+      log_type: "invalid_type"
+    )
+    assert_not point_log.valid?
+    assert_includes point_log.errors[:log_type], "is not included in the list"
+  end
+
+  # Log types
+  test "accepts 'attendance' as log_type" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 5,
+      reason: "Event attendance",
+      awarded_by: @staff_user,
+      log_type: "attendance"
+    )
+    assert point_log.valid?
+  end
+
+  test "accepts 'redemption' as log_type" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: -20,
+      reason: "Incentive redemption",
+      awarded_by: @staff_user,
+      log_type: "redemption"
+    )
+    assert point_log.valid?
+  end
+
+  test "accepts 'adjustment' as log_type" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 15,
+      reason: "Manual adjustment",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  # Points can be positive or negative
+  test "accepts positive points" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 100,
+      reason: "Bonus points",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  test "accepts negative points" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: -50,
+      reason: "Point deduction",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  test "accepts zero points" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 0,
+      reason: "No change",
+      awarded_by: @staff_user,
+      log_type: "adjustment"
+    )
+    assert point_log.valid?
+  end
+
+  # Polymorphic source association
+  test "can have a polymorphic source" do
+    event_type = EventType.create!(name: "Test Event", category: "org", point_value: 10)
+    event = Event.create!(name: "Test", event_date: Time.current, event_type: event_type, created_by: @staff_user)
+    event_log = EventLog.create!(user: @mentee_user, event: event, points_awarded: 10, log_type: "arrived")
+
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Event attendance",
+      awarded_by: @staff_user,
+      log_type: "attendance",
+      source: event_log
+    )
+
+    assert point_log.valid?
+    assert_equal event_log, point_log.source
+  end
+
+  test "source is optional" do
+    point_log = PointLog.new(
+      mentee: @mentee,
+      points: 10,
+      reason: "Manual adjustment",
+      awarded_by: @staff_user,
+      log_type: "adjustment",
+      source: nil
+    )
+    assert point_log.valid?
+  end
+
+  # Scopes and class methods
+  test "ordered by created_at descending by default" do
+    PointLog.create!(mentee: @mentee, points: 10, reason: "First", awarded_by: @staff_user, log_type: "adjustment", created_at: 2.hours.ago)
+    PointLog.create!(mentee: @mentee, points: 20, reason: "Second", awarded_by: @staff_user, log_type: "adjustment", created_at: 1.hour.ago)
+    PointLog.create!(mentee: @mentee, points: 30, reason: "Third", awarded_by: @staff_user, log_type: "adjustment", created_at: Time.current)
+
+    logs = @mentee.point_logs.to_a
+    assert_equal [30, 20, 10], logs.map(&:points)
+  end
+end

--- a/test/services/authorization_test.rb
+++ b/test/services/authorization_test.rb
@@ -73,6 +73,10 @@ class AuthorizationTest < ActiveSupport::TestCase
     assert Authorization.can?(@user, :manage_mentees, :users)
   end
 
+  test "admin can manage points" do
+    assert Authorization.can?(@user, :manage_points, :users)
+  end
+
   # Staff permissions
   test "staff cannot delete users" do
     assert_not Authorization.can?(@staff_user, :delete, :users, @other_user)
@@ -98,6 +102,10 @@ class AuthorizationTest < ActiveSupport::TestCase
     assert Authorization.can?(@staff_user, :manage_mentees, :users)
   end
 
+  test "staff can manage points" do
+    assert Authorization.can?(@staff_user, :manage_points, :users)
+  end
+
   # Mentor permissions
   test "mentor can view users" do
     assert Authorization.can?(@mentor_user, :show, :users)
@@ -117,6 +125,10 @@ class AuthorizationTest < ActiveSupport::TestCase
 
   test "mentor cannot manage mentees" do
     assert_not Authorization.can?(@mentor_user, :manage_mentees, :users)
+  end
+
+  test "mentor cannot manage points" do
+    assert_not Authorization.can?(@mentor_user, :manage_points, :users)
   end
 
   # Guardian permissions
@@ -328,6 +340,10 @@ class AuthorizationTest < ActiveSupport::TestCase
 
   test "mentee cannot manage mentees" do
     assert_not Authorization.can?(@mentee_user, :manage_mentees, :users)
+  end
+
+  test "mentee cannot manage points" do
+    assert_not Authorization.can?(@mentee_user, :manage_points, :users)
   end
 
   # Volunteer comprehensive permissions

--- a/test/system/points_management_test.rb
+++ b/test/system/points_management_test.rb
@@ -1,0 +1,238 @@
+require "application_system_test_case"
+
+class PointsManagementTest < ApplicationSystemTestCase
+  def setup
+    @admin = create_user(email: "admin_pts@example.com")
+    @admin.activate!
+
+    @mentee_user = User.create!(email: "mentee_pts@example.com", password: "Password123!")
+    @mentee = Mentee.create!(user: @mentee_user)
+    @mentee_user.activate!
+
+    # Create a season for point calculations
+    today = Date.current
+    OlympicSeason.create!(
+      name: "Test Season",
+      start_month: (today - 1.month).month,
+      start_day: (today - 1.month).day,
+      end_month: (today + 1.month).month,
+      end_day: (today + 1.month).day
+    )
+  end
+
+  def login_as(user)
+    visit login_path
+    fill_in "email", with: user.email
+    fill_in "password", with: "Password123!"
+    click_button "Sign in"
+    assert_text "Dashboard", wait: 5
+  end
+
+  test "viewing point history" do
+    # Create some point logs
+    PointLog.create!(mentee: @mentee, points: 10, reason: "Event attendance", awarded_by: @admin, log_type: "attendance")
+    PointLog.create!(mentee: @mentee, points: -5, reason: "Gift card redemption", awarded_by: @admin, log_type: "redemption")
+
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Check points display
+    assert_text "Points"
+    assert_text "5"
+
+    # Click History link
+    click_on "History"
+
+    # Should be on point history page
+    assert_text "Points History"
+    assert_text "Event attendance"
+    assert_text "Gift card redemption"
+    assert_text "Attendance"
+    assert_text "Redemption"
+  end
+
+  test "managing points - add points" do
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Check current points
+    assert_text "Points"
+    assert_text "0"
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Increment points
+    within("#manage-points-modal") do
+      click_button class: "bg-indigo-100"
+    end
+
+    # Fill in reason
+    fill_in "Reason", with: "Great participation in class"
+
+    # Save
+    click_on "Save"
+
+    # Should redirect back to user page - check points updated
+    assert_text "1", wait: 5
+
+    # Verify point log was created
+    @mentee.reload
+    assert_equal 1, @mentee.total_points
+  end
+
+  test "managing points - subtract points" do
+    # Give mentee some points first
+    PointLog.create!(mentee: @mentee, points: 20, reason: "Initial points", awarded_by: @admin, log_type: "adjustment")
+
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    assert_text "20"
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Decrement points twice
+    within("#manage-points-modal") do
+      2.times { click_button class: "bg-gray-100" }
+    end
+
+    # Fill in reason
+    fill_in "Reason", with: "Missed attendance"
+
+    # Save
+    click_on "Save"
+
+    # Should redirect back to user page - check points updated
+    assert_text "18", wait: 5
+
+    # Verify point log was created
+    @mentee.reload
+    assert_equal 18, @mentee.total_points
+  end
+
+  test "managing points with message" do
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Add points
+    within("#manage-points-modal") do
+      click_button class: "bg-indigo-100"
+    end
+
+    # Fill in reason
+    fill_in "Reason", with: "Excellent behavior"
+
+    # Check send message checkbox
+    check "Send message with points modification"
+
+    # Message area should appear and fill it
+    fill_in "Message", with: "Keep up the great work!"
+
+    # Save
+    click_on "Save"
+
+    # Should show success - check points updated
+    assert_text "1", wait: 5
+
+    # Verify message was sent
+    assert_equal 1, Message.count
+    message = Message.first
+    assert_equal @mentee_user, message.recipients.first
+  end
+
+  test "cannot reduce points below zero" do
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Try to decrement (should be prevented by UI logic)
+    within("#manage-points-modal") do
+      # Get the initial value
+      initial_result = find("[data-points-manager-target='resultDisplay']").text
+
+      # Try to click decrement
+      click_button class: "bg-gray-100"
+
+      # Result should not change (still at 0, can't go negative)
+      result = find("[data-points-manager-target='resultDisplay']").text
+      assert_equal initial_result, result
+    end
+  end
+
+  test "mentor cannot manage points" do
+    mentor_user = User.create!(email: "mentor_pts@example.com", password: "Password123!")
+    Mentor.create!(user: mentor_user)
+    mentor_user.activate!
+
+    login_as(mentor_user)
+    visit user_path(@mentee_user)
+
+    # Should not see Manage Points button
+    assert_no_text "Manage Points"
+  end
+
+  test "reason is required" do
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Add points
+    within("#manage-points-modal") do
+      click_button class: "bg-indigo-100"
+    end
+
+    # Don't fill in reason, just save
+    click_on "Save"
+
+    # Should show error or stay on page
+    # Since the modal doesn't close without reason validation
+    assert_text "Manage Points"
+  end
+
+  test "zero points adjustment is rejected" do
+    login_as(@admin)
+    visit user_path(@mentee_user)
+
+    # Open manage points modal
+    click_on "Manage Points"
+
+    # Modal should be visible
+    assert_text "Manage Points", wait: 5
+
+    # Don't change points (leave at 0)
+    # Fill in reason
+    fill_in "Reason", with: "No change"
+
+    click_on "Save"
+
+    # Points should stay at 0 (no change since adjustment was 0)
+    # The form may or may not show an error, but points shouldn't change
+    visit user_path(@mentee_user) # Refresh to check points
+    assert_text "Points"
+    assert_text "0"
+  end
+end

--- a/test/system/redemptions_system_test.rb
+++ b/test/system/redemptions_system_test.rb
@@ -19,7 +19,7 @@ class RedemptionsSystemTest < ApplicationSystemTestCase
     )
     event_type = EventType.create!(name: "Test Event", category: "org", point_value: 100)
     event = Event.create!(name: "Points Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 100, log_type: "arrived")
 
     @incentive = Incentive.create!(
       name: "Test Gift Card",

--- a/test/system/rewards_system_test.rb
+++ b/test/system/rewards_system_test.rb
@@ -18,7 +18,7 @@ class RewardsSystemTest < ApplicationSystemTestCase
     )
     event_type = EventType.create!(name: "Test Event", category: "org", point_value: 50)
     event = Event.create!(name: "Points Event", event_date: Time.current, event_type: event_type, created_by: @admin)
-    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50)
+    EventLog.create!(user: @mentee_user, event: event, points_awarded: 50, log_type: "arrived")
 
     @incentive = Incentive.create!(
       name: "Test Gift Card",


### PR DESCRIPTION
## Summary

This PR implements a comprehensive points history and management system for the High Aspirations platform.

### Changes

**Database & Models**
- Create  table as the single source of truth for all point activity
- Add  model with support for attendance, redemption, and adjustment types
- Update  to calculate from 
- Backfill historical data from existing  and 

**Data Flow**
- EventLog automatically creates point_logs when mentees arrive at events
- Redemption creates negative point_logs on creation
- Redemption creates refund point_logs when deleted with refund
- Manual adjustments via staff interface create adjustment point_logs

**Authorization**
- Add  permission for admin and staff roles
- Mentors and other roles cannot manage points

**UI/UX**
- Add Points display to mentee profile with current total
- History link navigates to paginated point history page
- Manage Points button opens modal for point adjustments
- Real-time preview of points after adjustment
- Optional message checkbox sends notification to mentee

**Security**
-  is nullable (no hardcoded system user)
- Historical data uses null awarded_by
- Proper authorization checks on all actions

**Testing**
- 52 model tests for PointLog and updated Mentee tests
- Authorization tests for manage_points permission  
- Controller tests for point_history and adjust_points actions
- System tests covering all UI interactions
- All 1160 tests passing

### Screenshots

[Points display on profile]
[Point History page]
[Manage Points modal]

### Acceptance Criteria

- [x] Mentee total points display on profile
- [x] User can open Points History
- [x] Points History displays paginated rows with Type, Awarded On, Awarded By, # of Points, Reason
- [x] User can open Manage Points modal
- [x] User can increase or decrease points
- [x] Point total cannot go below 0
- [x] Reason is required to save
- [x] Optional message can be sent with the adjustment

---

Closes: Points - History/manage ticket