### PR TITLE
Prep dev branch: Dependabot, CI, gated QA deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -39,6 +39,14 @@ jobs:
     needs: test
     # Gate until the QA VPS and secrets are ready. Flip via repo variable:
     # Settings → Secrets and variables → Actions → Variables → DEV_DEPLOY_ENABLED=true
+    #
+    # Enable checklist (do not skip):
+    # 1. Replace 0.0.0.0 in config/deploy.dev.yml with the real QA VPS IP (required before enable).
+    # 2. Confirm proxy.host DNS points at that host.
+    # 3. Prefer a separate RAILS_MASTER_KEY + credentials for QA — reusing production's
+    #    master key decrypts the same secrets (API keys, etc.) on the QA box.
+    # 4. Prefer a deploy SSH key limited to the QA host (not the prod key).
+    # 5. Then set DEV_DEPLOY_ENABLED=true.
     if: ${{ vars.DEV_DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
 
@@ -55,15 +63,18 @@ jobs:
     - name: Setup SSH 🔑
       uses: webfactory/ssh-agent@v0.10.0
       with:
-        ssh-private-key: ${{ secrets.HA_DEPLOY_KEY }}
+        # Prefer a QA-only key when available; falls back until provisioned.
+        ssh-private-key: ${{ secrets.HA_DEV_DEPLOY_KEY || secrets.HA_DEPLOY_KEY }}
 
-    - name: Create .kamal/secrets File 📁💥
+    - name: Create Kamal destination secrets file
+      # kamal deploy -d dev loads .kamal/secrets-common and .kamal/secrets.dev
+      # (not plain .kamal/secrets). See Kamal::Secrets#secrets_filenames.
       run: |
         mkdir -p .kamal
-        cat > .kamal/secrets <<EOF
-        KAMAL_REGISTRY_PASSWORD=${{ secrets.KAMAL_REGISTRY_PASSWORD }}
-        RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
-        EOF
+        {
+          echo "KAMAL_REGISTRY_PASSWORD=${{ secrets.KAMAL_REGISTRY_PASSWORD }}"
+          echo "RAILS_MASTER_KEY=${{ secrets.DEV_RAILS_MASTER_KEY || secrets.RAILS_MASTER_KEY }}"
+        } > .kamal/secrets.dev
 
     - name: Deploy with Kamal (dev destination) 🚀
       run: bundle exec kamal deploy -d dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,10 +43,11 @@ jobs:
     # Enable checklist (do not skip):
     # 1. Replace 0.0.0.0 in config/deploy.dev.yml with the real QA VPS IP (required before enable).
     # 2. Confirm proxy.host DNS points at that host.
-    # 3. Prefer a separate RAILS_MASTER_KEY + credentials for QA — reusing production's
-    #    master key decrypts the same secrets (API keys, etc.) on the QA box.
-    # 4. Prefer a deploy SSH key limited to the QA host (not the prod key).
-    # 5. Then set DEV_DEPLOY_ENABLED=true.
+    # 3. Create QA-only Actions secrets (no production fallbacks):
+    #      DEV_RAILS_MASTER_KEY  — master key for QA credentials, not production's
+    #      HA_DEV_DEPLOY_KEY     — SSH key limited to the QA host
+    #      KAMAL_REGISTRY_PASSWORD may be shared if the same registry namespace is fine
+    # 4. Then set DEV_DEPLOY_ENABLED=true.
     if: ${{ vars.DEV_DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
 
@@ -63,17 +64,18 @@ jobs:
     - name: Setup SSH 🔑
       uses: webfactory/ssh-agent@v0.10.0
       with:
-        # Prefer a QA-only key when available; falls back until provisioned.
-        ssh-private-key: ${{ secrets.HA_DEV_DEPLOY_KEY || secrets.HA_DEPLOY_KEY }}
+        # QA host only — never production HA_DEPLOY_KEY.
+        ssh-private-key: ${{ secrets.HA_DEV_DEPLOY_KEY }}
 
     - name: Create Kamal destination secrets file
       # kamal deploy -d dev loads .kamal/secrets-common and .kamal/secrets.dev
       # (not plain .kamal/secrets). See Kamal::Secrets#secrets_filenames.
+      # DEV_RAILS_MASTER_KEY only — never production RAILS_MASTER_KEY.
       run: |
         mkdir -p .kamal
         {
           echo "KAMAL_REGISTRY_PASSWORD=${{ secrets.KAMAL_REGISTRY_PASSWORD }}"
-          echo "RAILS_MASTER_KEY=${{ secrets.DEV_RAILS_MASTER_KEY || secrets.RAILS_MASTER_KEY }}"
+          echo "RAILS_MASTER_KEY=${{ secrets.DEV_RAILS_MASTER_KEY }}"
         } > .kamal/secrets.dev
 
     - name: Deploy with Kamal (dev destination) 🚀

--- a/config/deploy.dev.yml
+++ b/config/deploy.dev.yml
@@ -1,18 +1,21 @@
 # Destination overrides for the QA/dev environment.
 # Used with: kamal deploy -d dev
 #
-# Prep only — fill in servers and proxy host when the VPS is ready, then enable
-# the deploy job via repo variable DEV_DEPLOY_ENABLED=true
-# (see .github/workflows/deploy-dev.yml).
-
-# Distinct service name so containers never collide with production if they
-# ever share a host.
-service: ha_web-dev
+# Prep only. Before setting DEV_DEPLOY_ENABLED=true:
+#   1. Replace servers.web with the real QA VPS IP (do not enable while 0.0.0.0 remains).
+#   2. Confirm proxy.host DNS.
+#   3. Prefer a separate Rails master key + credentials for QA (not production's).
+#   4. Prefer a deploy SSH key limited to the QA host.
+# See .github/workflows/deploy-dev.yml enable checklist.
+#
+# Isolation: keep base service name (ha_web). Kamal already suffixes the
+# destination (service_and_destination → ha_web-dev). Volume name stays
+# distinct so storage never collides with production.
 
 # Deploy to these servers.
 servers:
   web:
-    # TODO: replace with QA/dev VPS IP when provisioned
+    # TODO: replace with QA/dev VPS IP when provisioned — required before enabling deploy.
     - 0.0.0.0
 
 proxy:

--- a/config/deploy.dev.yml
+++ b/config/deploy.dev.yml
@@ -4,8 +4,8 @@
 # Prep only. Before setting DEV_DEPLOY_ENABLED=true:
 #   1. Replace servers.web with the real QA VPS IP (do not enable while 0.0.0.0 remains).
 #   2. Confirm proxy.host DNS.
-#   3. Prefer a separate Rails master key + credentials for QA (not production's).
-#   4. Prefer a deploy SSH key limited to the QA host.
+#   3. Create QA-only Actions secrets: DEV_RAILS_MASTER_KEY, HA_DEV_DEPLOY_KEY
+#      (never reuse production RAILS_MASTER_KEY / HA_DEPLOY_KEY).
 # See .github/workflows/deploy-dev.yml enable checklist.
 #
 # Isolation: keep base service name (ha_web). Kamal already suffixes the


### PR DESCRIPTION
## What problem is this solving?

We want a QA/dev integration path so dependency updates and feature work land on `dev` first, instead of every merge to `main` shipping straight to production (and racing multiple Kamal deploys). The QA VPS is not ready yet, so this only prepares the branch and automation.

## What changed?

1. **Dependabot** targets `dev` only (bundler, github-actions, docker) — promote to prod via `dev → main` PR.
2. **CI** also runs on pushes to `dev`.
3. **Production deploy** concurrency group (`deploy-production`, no cancel-in-progress) so rapid merges queue instead of spamming Kamal.
4. **`config/deploy.dev.yml`** — Kamal destination overrides (placeholder host/DNS, distinct service + volume names).
5. **`deploy-dev.yml`** — on push to `dev`: always run tests; deploy job only when repo variable `DEV_DEPLOY_ENABLED=true`. Uses `kamal deploy -d dev`. Same concurrency pattern as prod.

## How to review

- `.github/dependabot.yml` — `target-branch: dev` on all ecosystems
- `.github/workflows/ci.yml` — `main, dev`
- `.github/workflows/deploy.yml` — concurrency only
- `.github/workflows/deploy-dev.yml` — gated deploy
- `config/deploy.dev.yml` — placeholders + isolation (`ha_web-dev`, separate volume)

## How we verified

- Config reviewed against current Kamal prod `config/deploy.yml` and GitHub Actions concurrency docs.
- No app code changes; no unit tests apply.
- Residual: `dev` branch must exist (created separately from current tip); after merge, keep `dev` in sync with `main` once. Flip `DEV_DEPLOY_ENABLED` and fill deploy.dev.yml when the VPS is ready.

## Out of scope

- Provisioning the QA VPS / DNS / secrets
- Enabling automatic dev deploys (`DEV_DEPLOY_ENABLED`)
- Branch protection rules
- Changing the production host or deploy path beyond concurrency

## After merge

1. Ensure long-lived `dev` exists and includes this commit (or merge `main` into `dev`).
2. Later: set host/DNS in `config/deploy.dev.yml`, add any secrets, set Actions variable `DEV_DEPLOY_ENABLED=true`.